### PR TITLE
Ordinary kriging

### DIFF
--- a/kriging/ordinary_kriging_interpolation.ipynb
+++ b/kriging/ordinary_kriging_interpolation.ipynb
@@ -4,7 +4,7 @@
   "metadata": {
     "colab": {
       "provenance": [],
-      "authorship_tag": "ABX9TyMdd9D4DtDClXjKdxIm5VmJ",
+      "authorship_tag": "ABX9TyPFF4b2Ve50pvsWPe+rUyZR",
       "include_colab_link": true
     },
     "kernelspec": {
@@ -819,7 +819,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "metadata": {
         "id": "RaZDahrojjPQ",
         "colab": {
@@ -867,7 +867,7 @@
         },
         "outputId": "3b309d25-0660-4ed8-8f58-a11a1abf7514"
       },
-      "execution_count": 3,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -903,7 +903,7 @@
       "metadata": {
         "id": "Ff9kNIMWjrON"
       },
-      "execution_count": 4,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -915,10 +915,8 @@
         "\n",
         "import ddfimport\n",
         "\n",
-        "if DEBUG:\n",
-        "  ddfimport.ddf_source_control_pane()\n",
-        "else:\n",
-        "  ddfimport.ddf_import_common()"
+        "ddfimport.ddf_source_control_pane()\n",
+        "# ddfimport.ddf_import_common()"
       ],
       "metadata": {
         "colab": {
@@ -953,7 +951,7 @@
         "id": "y15ijUt5sdYs",
         "outputId": "3b07938e-0b43-4b60-f396-0c163989fbd0"
       },
-      "execution_count": 13,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -993,7 +991,7 @@
         },
         "outputId": "12d88c3c-ec00-4005-8813-5ff9de94e2e5"
       },
-      "execution_count": 14,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1020,7 +1018,7 @@
       "metadata": {
         "id": "YIbO9KZL7jzJ"
       },
-      "execution_count": 15,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -1040,7 +1038,7 @@
       "metadata": {
         "id": "eD7g_1plr8Fv"
       },
-      "execution_count": 20,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -1057,7 +1055,7 @@
         "id": "fLoYftYc23JC",
         "outputId": "4d809657-61ea-4b12-a2b4-8c59637f4933"
       },
-      "execution_count": 16,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -1094,34 +1092,8 @@
       "metadata": {
         "id": "zuw47FvLI_p7"
       },
-      "execution_count": 21,
+      "execution_count": null,
       "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Load Amazon geometry dataset that'll be used to mask isoscape in expected shape.\n",
-        "amazon_biome_path = os.path.join(PROJECT_BASE, BIOME_PATH)\n",
-        "gdf_amazon = gpd.read_file(amazon_biome_path)"
-      ],
-      "metadata": {
-        "id": "vcMeFUVpHyNN",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "5254be6d-7fc7-4f17-93e4-98a72393e3fd"
-      },
-      "execution_count": 17,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.10/dist-packages/geopandas/array.py:93: ShapelyDeprecationWarning: __len__ for multi-part geometries is deprecated and will be removed in Shapely 2.0. Check the length of the `geoms` property instead to get the  number of parts of a multi-part geometry.\n",
-            "  aout[:] = out\n"
-          ]
-        }
-      ]
     },
     {
       "cell_type": "code",
@@ -1171,20 +1143,20 @@
       "metadata": {
         "id": "u9-Ga8NM-duR"
       },
-      "execution_count": 22,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "code",
       "source": [
-        "def display_isoscape(means_filename, vars_filename, gdf_amazon):\n",
+        "def display_isoscape(means_filename, vars_filename, gdf_biome):\n",
         "  '''\n",
         "  Given a filename to a RasterIO file containing an isoscape raster,\n",
-        "  display the isoscape masked by the gdf_amazon geometry.\n",
+        "  display the isoscape masked by the gdf_biome geometry.\n",
         "  '''\n",
         "  # Mean Isotope Isoscape Band Image\n",
         "  means_raster = rasterio.open(means_filename)\n",
-        "  means_image, means_transform = rio.mask.mask(means_raster, gdf_amazon.geometry.values, crop = True)\n",
+        "  means_image, means_transform = rio.mask.mask(means_raster, gdf_biome.geometry.values, crop = True)\n",
         "\n",
         "  fig, (ax1, ax2) = plt.subplots(1, 2, figsize = (20, 20))\n",
         "  means_raster_images = show(means_image, ax = ax1, transform = means_transform, cmap = \"RdYlGn\")\n",
@@ -1195,7 +1167,7 @@
         "\n",
         "  # Variance Isotope Isoscape Band Image\n",
         "  vars_raster = rasterio.open(vars_filename)\n",
-        "  vars_image, vars_transform = rio.mask.mask(vars_raster, gdf_amazon.geometry.values, crop = True)\n",
+        "  vars_image, vars_transform = rio.mask.mask(vars_raster, gdf_biome.geometry.values, crop = True)\n",
         "\n",
         "  vars_raster_images = show(vars_image, ax = ax2, transform = vars_transform, cmap = \"RdYlGn\")\n",
         "  vars_raster_image = vars_raster_images.get_images()[0]\n",
@@ -1207,12 +1179,13 @@
       "metadata": {
         "id": "ipGXn_xN2Oin"
       },
-      "execution_count": 23,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "code",
       "source": [
+        "# TODO: Use standard raster dimensions and resolution.\n",
         "atmosphere_isoscape_geotiff = raster.load_raster(raster.get_raster_path(\"brasil_clim_raster.tiff\"))\n",
         "bounds =  raster.get_extent(atmosphere_isoscape_geotiff.gdal_dataset)"
       ],
@@ -1223,7 +1196,7 @@
         "id": "LleG8sZhD8BQ",
         "outputId": "3483a74a-67c0-472e-eafd-3db075cf1d83"
       },
-      "execution_count": 24,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -1251,7 +1224,7 @@
         "id": "aQQIRXcACwAy",
         "outputId": "2da2d035-569a-4f3b-90e8-2bd3ca183b27"
       },
-      "execution_count": 25,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -1291,13 +1264,39 @@
       "metadata": {
         "id": "YxOQyUAUApxH"
       },
-      "execution_count": 26,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "code",
       "source": [
-        "display_isoscape(out_filename_mean, out_filename_var, gdf_amazon)"
+        "# Load geometry dataset that'll be used to mask isoscape in expected shape.\n",
+        "biome_path = os.path.join(PROJECT_BASE, BIOME_PATH)\n",
+        "gdf_biome = gpd.read_file(biome_path)"
+      ],
+      "metadata": {
+        "id": "vcMeFUVpHyNN",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "5254be6d-7fc7-4f17-93e4-98a72393e3fd"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.10/dist-packages/geopandas/array.py:93: ShapelyDeprecationWarning: __len__ for multi-part geometries is deprecated and will be removed in Shapely 2.0. Check the length of the `geoms` property instead to get the  number of parts of a multi-part geometry.\n",
+            "  aout[:] = out\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "display_isoscape(out_filename_mean, out_filename_var, gdf_biome)"
       ],
       "metadata": {
         "colab": {
@@ -1307,7 +1306,7 @@
         "id": "QXKWM7nQPHDu",
         "outputId": "e68ba246-461d-4ce9-addc-4a0c74c42b42"
       },
-      "execution_count": 27,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",


### PR DESCRIPTION
Notebook to generate baseline oxygen mean and variance isoscapes.

Resulting isoscapes under different partitions and grouping strategies (start at slide 24):
https://docs.google.com/presentation/d/1BcYY-Oj-mUgY_AZ_h9FzRIkOZfaRXrcs5pL6ipkYEHY/edit?usp=sharing

Future improvements:
- Try other variogram_models other than "linear"
- Try something other than ordinary Kriging

Out of scope for this review:
- RMSE calculation on the generated isoscapes (will do in a subsequent PR as part of the validation pipeline)