### PR TITLE
Correct button pointing to outdated notebook.

### DIFF
--- a/data_ingestion.ipynb
+++ b/data_ingestion.ipynb
@@ -22,7 +22,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/tnc-br/ddf-isoscapes/blob/validation_mount_gdrive/data_ingestion.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/tnc-br/ddf-isoscapes/blob/fix-button/data_ingestion.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -335,7 +335,6 @@
         "test_data = resulting_dataset.test"
       ],
       "metadata": {
-        "cellView": "form",
         "id": "fnBXzjLYDC35"
       },
       "execution_count": null,


### PR DESCRIPTION
The button in the notebook "Open in Colab" has been pointing to an outdated notebook.