### PR TITLE
Update variational inference notebook with sensible defaults to work of-the-box

### DIFF
--- a/dnn/variational_inference.ipynb
+++ b/dnn/variational_inference.ipynb
@@ -3,16 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/tnc-br/ddf-isoscapes/blob/column_params/dnn/variational_inference.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "-0IfT3kGwgK6"
       },
       "source": [
@@ -29,14 +19,14 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "henIPlAPCb4i",
-        "outputId": "a800f594-db57-4f9b-e99c-7bb283eef16b"
+        "outputId": "50579b7b-7c02-4dbd-aa6a-34f0d7d7d9aa"
       },
       "outputs": [
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Mounted at /content/gdrive\n"
+            "Drive already mounted at /content/gdrive; to attempt to forcibly remount, call drive.mount(\"/content/gdrive\", force_remount=True).\n"
           ]
         }
       ],
@@ -84,9 +74,9 @@
         "\n",
         "MODEL_NAME = \"demo_isoscape_model\" #@param\n",
         "\n",
-        "TRAINING_SET_PATH = 'amazon_sample_data/canonical/uc_davis_train_fixed_grouped.csv' #@param\n",
-        "VALIDATION_SET_PATH = 'amazon_sample_data/canonical/uc_davis_validation_fixed_grouped.csv' #@param\n",
-        "TEST_SET_PATH = 'amazon_sample_data/canonical/uc_davis_test_fixed_grouped.csv' #@param\n",
+        "TRAINING_SET_PATH = 'amazon_sample_data/demo_train_fixed_grouped.csv' #@param\n",
+        "VALIDATION_SET_PATH = 'amazon_sample_data/demo_validation_fixed_grouped.csv' #@param\n",
+        "TEST_SET_PATH = 'amazon_sample_data/demo_test_fixed_grouped.csv' #@param\n",
         "\n",
         "TRAINING_COLUMNS_TO_STANDARDIZE = ['lat', 'long', 'VPD', 'RH', 'PET', 'DEM', 'PA', 'Mean Annual Temperature', 'Mean Annual Precipitation', 'Iso_Oxi_Stack_mean_TERZER', 'isoscape_fullmodel_d18O_prec_REGRESSION', 'brisoscape_mean_ISORIX', 'd13C_cel_mean', 'd13C_cel_var', 'ordinary_kriging_linear_d18O_predicted_mean', 'ordinary_kriging_linear_d18O_predicted_variance'] #@param\n",
         "TRAINING_COLUMNS_TO_SCALE = [] #@param\n",
@@ -112,18 +102,33 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 2,
       "metadata": {
-        "id": "AXh86HFwXiax"
+        "id": "AXh86HFwXiax",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "0650f23b-1d4c-40e4-8f66-171c831b3f4e"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "executing checkout_branch ...\n",
+            "b''\n",
+            "main branch checked out as readonly. You may now use ddf_common imports\n"
+          ]
+        }
+      ],
       "source": [
         "import sys\n",
         "\n",
         "!if [ ! -d \"/content/ddf_common_stub\" ] ; then git clone -b test https://github.com/tnc-br/ddf_common_stub.git; fi\n",
         "sys.path.append(\"/content/ddf_common_stub/\")\n",
         "import ddfimport\n",
-        "ddfimport.ddf_import_common()"
+        "ddfimport.ddf_import_common()\n",
+        "#ddfimport.ddf_source_control_pane()"
       ]
     },
     {
@@ -134,14 +139,14 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "0mUB0y0AXivp",
-        "outputId": "3b436e4d-30e5-4d58-d657-1338ef350e78"
+        "outputId": "f0d60567-b6c0-444f-e4e5-e1eb486a9031"
       },
       "outputs": [
         {
           "output_type": "execute_result",
           "data": {
             "text/plain": [
-              "<module 'dataset' from '/content/gdrive/MyDrive/nudge/ddf_common/dataset.py'>"
+              "<module 'dataset' from '/tmp/ddf_common/dataset.py'>"
             ]
           },
           "metadata": {},
@@ -176,7 +181,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": 4,
       "metadata": {
         "id": "6XMee1aHfcik"
       },
@@ -211,7 +216,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": 30,
       "metadata": {
         "id": "XSDwdvMkb7w8"
       },
@@ -255,7 +260,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": 31,
       "metadata": {
         "id": "_kf2e_fKon2P"
       },
@@ -323,7 +328,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": 32,
       "metadata": {
         "id": "urGjYNNnemX6"
       },
@@ -391,16 +396,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 45,
       "metadata": {
         "id": "HCkGSPUo3KqY"
       },
       "outputs": [],
       "source": [
         "from keras.callbacks import ModelCheckpoint, EarlyStopping\n",
+        "from keras.initializers import glorot_normal\n",
         "\n",
         "def get_early_stopping_callback():\n",
-        "  return EarlyStopping(monitor='val_loss', patience=1000, min_delta=0.001,\n",
+        "  return EarlyStopping(monitor='val_loss', patience=30, min_delta=0.001,\n",
         "                       verbose=1, restore_best_weights=True, start_from_epoch=0)\n",
         "\n",
         "tf.keras.utils.set_random_seed(18731)\n",
@@ -427,13 +433,13 @@
         "    x = inputs\n",
         "    for layer_size in hidden_layers:\n",
         "      x = keras.layers.Dense(\n",
-        "          layer_size, activation='relu')(x)\n",
+        "          layer_size, activation='relu', kernel_initializer=glorot_normal)(x)\n",
         "    mean_output = keras.layers.Dense(\n",
-        "        1, name='mean_output')(x)\n",
+        "        1, name='mean_output', kernel_initializer=glorot_normal)(x)\n",
         "\n",
         "    # We can not have negative variance. Apply very little variance.\n",
         "    var_output = keras.layers.Dense(\n",
-        "        1, name='var_output')(x)\n",
+        "        1, name='var_output', kernel_initializer=glorot_normal)(x)\n",
         "\n",
         "    # Invert the normalization on our outputs\n",
         "    mean_scaler = sp.label_scaler.named_transformers_['mean_std_scaler']\n",
@@ -461,7 +467,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 46,
       "metadata": {
         "id": "DALuUm8UOgNu"
       },
@@ -517,12 +523,54 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 43,
       "metadata": {
         "collapsed": true,
-        "id": "rPONfgkjvJWz"
+        "id": "rPONfgkjvJWz",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "e7fa56c5-f0ce-4a88-fa22-adefeadfdc1c"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Driver: GTiff/GeoTIFF\n",
+            "Size is 541 x 467 x 1\n",
+            "Projection is GEOGCS[\"SIRGAS 2000\",DATUM[\"Sistema_de_Referencia_Geocentrico_para_las_AmericaS_2000\",SPHEROID[\"GRS 1980\",6378137,298.257222101004,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6674\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4674\"]]\n",
+            "Origin = (-73.922043, 5.233124)\n",
+            "Pixel Size = (0.08333, -0.08333)\n",
+            "Driver: GTiff/GeoTIFF\n",
+            "Size is 235 x 218 x 2\n",
+            "Projection is GEOGCS[\"SIRGAS 2000\",DATUM[\"Sistema_de_Referencia_Geocentrico_para_las_AmericaS_2000\",SPHEROID[\"GRS 1980\",6378137,298.257222101004,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6674\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4674\"]]\n",
+            "Origin = (-74.0, 4.500000000659528)\n",
+            "Pixel Size = (0.166666666667993, -0.16666666666799657)\n",
+            "Driver: GTiff/GeoTIFF\n",
+            "Size is 235 x 218 x 2\n",
+            "Projection is GEOGCS[\"SIRGAS 2000\",DATUM[\"Sistema_de_Referencia_Geocentrico_para_las_AmericaS_2000\",SPHEROID[\"GRS 1980\",6378137,298.257222101004,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6674\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4674\"]]\n",
+            "Origin = (-74.0, 4.500000000659528)\n",
+            "Pixel Size = (0.166666666667993, -0.16666666666799657)\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "Index(['lat', 'long', 'VPD', 'RH', 'PET', 'DEM', 'PA',\n",
+              "       'Mean Annual Temperature', 'Mean Annual Precipitation',\n",
+              "       'Iso_Oxi_Stack_mean_TERZER', 'brisoscape_mean_ISORIX',\n",
+              "       'isoscape_fullmodel_d18O_prec_REGRESSION', 'd13C_cel_mean',\n",
+              "       'd13C_cel_var', 'ordinary_kriging_linear_d18O_predicted_mean',\n",
+              "       'ordinary_kriging_linear_d18O_predicted_variance'],\n",
+              "      dtype='object')"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 43
+        }
+      ],
       "source": [
         "grouped_random_fileset = {\n",
         "    'TRAIN' : os.path.join(FP_ROOT, TRAINING_SET_PATH),\n",
@@ -550,22 +598,523 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 47,
       "metadata": {
-        "id": "cFuIPM4afQPd"
+        "id": "cFuIPM4afQPd",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "outputId": "765ccca5-eba6-4a7d-c4ba-04dda45d7de7"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "==================\n",
+            "demo_isoscape_model\n",
+            "Model: \"model_3\"\n",
+            "__________________________________________________________________________________________________\n",
+            " Layer (type)                Output Shape                 Param #   Connected to                  \n",
+            "==================================================================================================\n",
+            " input_4 (InputLayer)        [(None, 16)]                 0         []                            \n",
+            "                                                                                                  \n",
+            " dense_6 (Dense)             (None, 20)                   340       ['input_4[0][0]']             \n",
+            "                                                                                                  \n",
+            " dense_7 (Dense)             (None, 20)                   420       ['dense_6[0][0]']             \n",
+            "                                                                                                  \n",
+            " var_output (Dense)          (None, 1)                    21        ['dense_7[0][0]']             \n",
+            "                                                                                                  \n",
+            " mean_output (Dense)         (None, 1)                    21        ['dense_7[0][0]']             \n",
+            "                                                                                                  \n",
+            " tf.math.multiply_7 (TFOpLa  (None, 1)                    0         ['var_output[0][0]']          \n",
+            " mbda)                                                                                            \n",
+            "                                                                                                  \n",
+            " tf.math.multiply_6 (TFOpLa  (None, 1)                    0         ['mean_output[0][0]']         \n",
+            " mbda)                                                                                            \n",
+            "                                                                                                  \n",
+            " tf.__operators__.add_7 (TF  (None, 1)                    0         ['tf.math.multiply_7[0][0]']  \n",
+            " OpLambda)                                                                                        \n",
+            "                                                                                                  \n",
+            " tf.__operators__.add_6 (TF  (None, 1)                    0         ['tf.math.multiply_6[0][0]']  \n",
+            " OpLambda)                                                                                        \n",
+            "                                                                                                  \n",
+            " lambda_3 (Lambda)           (None, 1)                    0         ['tf.__operators__.add_7[0][0]\n",
+            "                                                                    ']                            \n",
+            "                                                                                                  \n",
+            " concatenate_3 (Concatenate  (None, 2)                    0         ['tf.__operators__.add_6[0][0]\n",
+            " )                                                                  ',                            \n",
+            "                                                                     'lambda_3[0][0]']            \n",
+            "                                                                                                  \n",
+            "==================================================================================================\n",
+            "Total params: 802 (3.13 KB)\n",
+            "Trainable params: 802 (3.13 KB)\n",
+            "Non-trainable params: 0 (0.00 Byte)\n",
+            "__________________________________________________________________________________________________\n",
+            "Epoch 1/5000\n",
+            " 1/30 [>.............................] - ETA: 43s - loss: 0.9772"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.10/dist-packages/keras/src/engine/training.py:3000: UserWarning: You are saving your model as an HDF5 file via `model.save()`. This file format is considered legacy. We recommend using instead the native Keras format, e.g. `model.save('my_model.keras')`.\n",
+            "  saving_api.save_model(\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\r30/30 [==============================] - 2s 27ms/step - loss: 1.9510 - val_loss: 3.7327\n",
+            "Epoch 2/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.8837 - val_loss: 3.0972\n",
+            "Epoch 3/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.9316 - val_loss: 2.5691\n",
+            "Epoch 4/5000\n",
+            "30/30 [==============================] - 0s 6ms/step - loss: 1.7660 - val_loss: 2.3854\n",
+            "Epoch 5/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.8205 - val_loss: 2.8918\n",
+            "Epoch 6/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.5253 - val_loss: 2.7126\n",
+            "Epoch 7/5000\n",
+            "30/30 [==============================] - 0s 2ms/step - loss: 1.5438 - val_loss: 2.7249\n",
+            "Epoch 8/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.7379 - val_loss: 3.0112\n",
+            "Epoch 9/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.6678 - val_loss: 2.4770\n",
+            "Epoch 10/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.6573 - val_loss: 2.9744\n",
+            "Epoch 11/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.3983 - val_loss: 2.6037\n",
+            "Epoch 12/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.5079 - val_loss: 3.1383\n",
+            "Epoch 13/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.5472 - val_loss: 2.9371\n",
+            "Epoch 14/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.3824 - val_loss: 2.9642\n",
+            "Epoch 15/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.3921 - val_loss: 3.3565\n",
+            "Epoch 16/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.3670 - val_loss: 3.2104\n",
+            "Epoch 17/5000\n",
+            "30/30 [==============================] - 0s 7ms/step - loss: 1.2733 - val_loss: 2.3747\n",
+            "Epoch 18/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.3692 - val_loss: 2.9345\n",
+            "Epoch 19/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.4483 - val_loss: 2.5991\n",
+            "Epoch 20/5000\n",
+            "30/30 [==============================] - 0s 6ms/step - loss: 1.3574 - val_loss: 2.6236\n",
+            "Epoch 21/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.4615 - val_loss: 2.7459\n",
+            "Epoch 22/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.2482 - val_loss: 2.7679\n",
+            "Epoch 23/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.2601 - val_loss: 2.3627\n",
+            "Epoch 24/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.2955 - val_loss: 2.8747\n",
+            "Epoch 25/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.2741 - val_loss: 3.2306\n",
+            "Epoch 26/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.4438 - val_loss: 2.5453\n",
+            "Epoch 27/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.2654 - val_loss: 2.3985\n",
+            "Epoch 28/5000\n",
+            "30/30 [==============================] - 0s 7ms/step - loss: 1.2163 - val_loss: 2.2722\n",
+            "Epoch 29/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.2730 - val_loss: 2.4714\n",
+            "Epoch 30/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.2323 - val_loss: 2.2971\n",
+            "Epoch 31/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.3223 - val_loss: 2.2289\n",
+            "Epoch 32/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.1650 - val_loss: 3.9629\n",
+            "Epoch 33/5000\n",
+            "30/30 [==============================] - 0s 6ms/step - loss: 1.3289 - val_loss: 2.1341\n",
+            "Epoch 34/5000\n",
+            "30/30 [==============================] - 0s 6ms/step - loss: 1.1653 - val_loss: 3.1861\n",
+            "Epoch 35/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.2595 - val_loss: 2.6919\n",
+            "Epoch 36/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.2132 - val_loss: 2.1028\n",
+            "Epoch 37/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.3297 - val_loss: 2.5435\n",
+            "Epoch 38/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.2001 - val_loss: 3.1557\n",
+            "Epoch 39/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.1318 - val_loss: 2.3649\n",
+            "Epoch 40/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.2728 - val_loss: 2.8803\n",
+            "Epoch 41/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.1772 - val_loss: 2.3082\n",
+            "Epoch 42/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.3059 - val_loss: 3.0154\n",
+            "Epoch 43/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.0789 - val_loss: 2.1918\n",
+            "Epoch 44/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.1541 - val_loss: 2.5864\n",
+            "Epoch 45/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.1471 - val_loss: 2.2607\n",
+            "Epoch 46/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.1520 - val_loss: 2.9380\n",
+            "Epoch 47/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.2134 - val_loss: 2.3894\n",
+            "Epoch 48/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.4134 - val_loss: 2.5074\n",
+            "Epoch 49/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.1468 - val_loss: 2.2582\n",
+            "Epoch 50/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.2576 - val_loss: 3.0398\n",
+            "Epoch 51/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.1947 - val_loss: 3.3911\n",
+            "Epoch 52/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.2622 - val_loss: 3.4115\n",
+            "Epoch 53/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.1908 - val_loss: 2.0464\n",
+            "Epoch 54/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.1906 - val_loss: 2.3739\n",
+            "Epoch 55/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.1177 - val_loss: 2.5737\n",
+            "Epoch 56/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.1507 - val_loss: 2.6622\n",
+            "Epoch 57/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.0939 - val_loss: 2.3187\n",
+            "Epoch 58/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.1017 - val_loss: 2.6080\n",
+            "Epoch 59/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.1525 - val_loss: 2.3466\n",
+            "Epoch 60/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.0957 - val_loss: 2.2665\n",
+            "Epoch 61/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.1160 - val_loss: 2.2454\n",
+            "Epoch 62/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.2630 - val_loss: 2.2419\n",
+            "Epoch 63/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.1562 - val_loss: 2.6437\n",
+            "Epoch 64/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.0255 - val_loss: 2.4853\n",
+            "Epoch 65/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.1095 - val_loss: 2.2521\n",
+            "Epoch 66/5000\n",
+            "30/30 [==============================] - 0s 6ms/step - loss: 1.1159 - val_loss: 2.3093\n",
+            "Epoch 67/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.1778 - val_loss: 2.1538\n",
+            "Epoch 68/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.1101 - val_loss: 2.4123\n",
+            "Epoch 69/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.1531 - val_loss: 2.5925\n",
+            "Epoch 70/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.1141 - val_loss: 2.1116\n",
+            "Epoch 71/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.1875 - val_loss: 2.0623\n",
+            "Epoch 72/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.0523 - val_loss: 2.3286\n",
+            "Epoch 73/5000\n",
+            "30/30 [==============================] - 0s 7ms/step - loss: 1.1704 - val_loss: 2.0384\n",
+            "Epoch 74/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.1738 - val_loss: 2.5751\n",
+            "Epoch 75/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.0331 - val_loss: 2.1409\n",
+            "Epoch 76/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.0482 - val_loss: 1.9081\n",
+            "Epoch 77/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.1077 - val_loss: 2.4975\n",
+            "Epoch 78/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.1376 - val_loss: 2.3850\n",
+            "Epoch 79/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.0697 - val_loss: 2.4210\n",
+            "Epoch 80/5000\n",
+            "30/30 [==============================] - 0s 6ms/step - loss: 1.1787 - val_loss: 2.9233\n",
+            "Epoch 81/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.0946 - val_loss: 2.1783\n",
+            "Epoch 82/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.2122 - val_loss: 2.3057\n",
+            "Epoch 83/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.1523 - val_loss: 2.0328\n",
+            "Epoch 84/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.1417 - val_loss: 2.0096\n",
+            "Epoch 85/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.1021 - val_loss: 2.7622\n",
+            "Epoch 86/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.1901 - val_loss: 1.9656\n",
+            "Epoch 87/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 0.9646 - val_loss: 2.3830\n",
+            "Epoch 88/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.0404 - val_loss: 1.9691\n",
+            "Epoch 89/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.1746 - val_loss: 1.9718\n",
+            "Epoch 90/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.1493 - val_loss: 1.8652\n",
+            "Epoch 91/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.0533 - val_loss: 2.0117\n",
+            "Epoch 92/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.1585 - val_loss: 2.0477\n",
+            "Epoch 93/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.0939 - val_loss: 2.0035\n",
+            "Epoch 94/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.0520 - val_loss: 2.1855\n",
+            "Epoch 95/5000\n",
+            "30/30 [==============================] - 0s 6ms/step - loss: 0.9838 - val_loss: 1.6651\n",
+            "Epoch 96/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.1534 - val_loss: 2.1736\n",
+            "Epoch 97/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.0841 - val_loss: 1.9322\n",
+            "Epoch 98/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.1014 - val_loss: 2.0471\n",
+            "Epoch 99/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.0897 - val_loss: 2.0651\n",
+            "Epoch 100/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.0304 - val_loss: 2.2929\n",
+            "Epoch 101/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.0190 - val_loss: 1.8337\n",
+            "Epoch 102/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.0801 - val_loss: 2.3597\n",
+            "Epoch 103/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 0.9770 - val_loss: 2.4286\n",
+            "Epoch 104/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 0.9841 - val_loss: 1.7097\n",
+            "Epoch 105/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.1226 - val_loss: 1.7990\n",
+            "Epoch 106/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.0685 - val_loss: 2.1710\n",
+            "Epoch 107/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.0015 - val_loss: 2.0242\n",
+            "Epoch 108/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.0534 - val_loss: 2.2767\n",
+            "Epoch 109/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.0273 - val_loss: 1.8782\n",
+            "Epoch 110/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 0.9595 - val_loss: 2.8640\n",
+            "Epoch 111/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.0028 - val_loss: 1.8443\n",
+            "Epoch 112/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.0750 - val_loss: 2.6062\n",
+            "Epoch 113/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.0105 - val_loss: 2.6132\n",
+            "Epoch 114/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.0373 - val_loss: 1.9296\n",
+            "Epoch 115/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 0.9824 - val_loss: 2.5361\n",
+            "Epoch 116/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.1026 - val_loss: 1.9459\n",
+            "Epoch 117/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 0.9985 - val_loss: 1.9126\n",
+            "Epoch 118/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.0754 - val_loss: 1.9687\n",
+            "Epoch 119/5000\n",
+            "30/30 [==============================] - 0s 6ms/step - loss: 1.0682 - val_loss: 1.9612\n",
+            "Epoch 120/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.0305 - val_loss: 1.4302\n",
+            "Epoch 121/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 0.9387 - val_loss: 2.3252\n",
+            "Epoch 122/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 0.9781 - val_loss: 2.0641\n",
+            "Epoch 123/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 0.9813 - val_loss: 2.1209\n",
+            "Epoch 124/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.0841 - val_loss: 1.7496\n",
+            "Epoch 125/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.0116 - val_loss: 1.7976\n",
+            "Epoch 126/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 0.9822 - val_loss: 2.1512\n",
+            "Epoch 127/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.0802 - val_loss: 1.8590\n",
+            "Epoch 128/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.1012 - val_loss: 2.1695\n",
+            "Epoch 129/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.0645 - val_loss: 1.7446\n",
+            "Epoch 130/5000\n",
+            "30/30 [==============================] - 0s 7ms/step - loss: 1.0444 - val_loss: 1.9847\n",
+            "Epoch 131/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 0.9501 - val_loss: 1.9467\n",
+            "Epoch 132/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.0530 - val_loss: 2.1598\n",
+            "Epoch 133/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 0.9841 - val_loss: 1.9811\n",
+            "Epoch 134/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 0.9594 - val_loss: 1.8823\n",
+            "Epoch 135/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.0387 - val_loss: 1.9713\n",
+            "Epoch 136/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 0.9317 - val_loss: 2.1460\n",
+            "Epoch 137/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 0.9717 - val_loss: 1.7590\n",
+            "Epoch 138/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 0.9459 - val_loss: 1.7432\n",
+            "Epoch 139/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.1174 - val_loss: 1.7049\n",
+            "Epoch 140/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 0.9413 - val_loss: 2.0390\n",
+            "Epoch 141/5000\n",
+            "30/30 [==============================] - 0s 6ms/step - loss: 1.0726 - val_loss: 1.7083\n",
+            "Epoch 142/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 0.9637 - val_loss: 1.7253\n",
+            "Epoch 143/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 0.9670 - val_loss: 1.6117\n",
+            "Epoch 144/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.0837 - val_loss: 1.5943\n",
+            "Epoch 145/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 0.9467 - val_loss: 2.2508\n",
+            "Epoch 146/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 1.0003 - val_loss: 2.0097\n",
+            "Epoch 147/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 0.9394 - val_loss: 1.3978\n",
+            "Epoch 148/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 0.9228 - val_loss: 2.0444\n",
+            "Epoch 149/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 0.8515 - val_loss: 1.6667\n",
+            "Epoch 150/5000\n",
+            "30/30 [==============================] - 0s 6ms/step - loss: 0.9900 - val_loss: 1.5307\n",
+            "Epoch 151/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 0.9350 - val_loss: 2.0336\n",
+            "Epoch 152/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 0.9188 - val_loss: 2.0068\n",
+            "Epoch 153/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 0.9921 - val_loss: 1.6768\n",
+            "Epoch 154/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 0.9137 - val_loss: 1.6438\n",
+            "Epoch 155/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 0.9625 - val_loss: 1.4986\n",
+            "Epoch 156/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 0.8874 - val_loss: 1.8696\n",
+            "Epoch 157/5000\n",
+            "30/30 [==============================] - 0s 6ms/step - loss: 1.0066 - val_loss: 1.7143\n",
+            "Epoch 158/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 0.9947 - val_loss: 1.9943\n",
+            "Epoch 159/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 1.0730 - val_loss: 1.6558\n",
+            "Epoch 160/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 0.9720 - val_loss: 1.7278\n",
+            "Epoch 161/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 0.9176 - val_loss: 1.5477\n",
+            "Epoch 162/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 0.9951 - val_loss: 1.6443\n",
+            "Epoch 163/5000\n",
+            "30/30 [==============================] - 0s 3ms/step - loss: 0.9876 - val_loss: 1.9034\n",
+            "Epoch 164/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 0.9260 - val_loss: 1.6561\n",
+            "Epoch 165/5000\n",
+            "30/30 [==============================] - 0s 6ms/step - loss: 0.8996 - val_loss: 1.5631\n",
+            "Epoch 166/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 0.9878 - val_loss: 1.7163\n",
+            "Epoch 167/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 0.9327 - val_loss: 1.9103\n",
+            "Epoch 168/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 0.9402 - val_loss: 1.8815\n",
+            "Epoch 169/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 0.9896 - val_loss: 1.6027\n",
+            "Epoch 170/5000\n",
+            "30/30 [==============================] - 0s 6ms/step - loss: 0.9498 - val_loss: 1.5487\n",
+            "Epoch 171/5000\n",
+            "30/30 [==============================] - 0s 7ms/step - loss: 0.9627 - val_loss: 1.7860\n",
+            "Epoch 172/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 0.9399 - val_loss: 1.8426\n",
+            "Epoch 173/5000\n",
+            "30/30 [==============================] - 0s 4ms/step - loss: 0.9688 - val_loss: 1.6356\n",
+            "Epoch 174/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 0.9690 - val_loss: 1.4623\n",
+            "Epoch 175/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 1.0110 - val_loss: 1.5856\n",
+            "Epoch 176/5000\n",
+            "30/30 [==============================] - 0s 5ms/step - loss: 0.9272 - val_loss: 1.7855\n",
+            "Epoch 177/5000\n",
+            "14/30 [=============>................] - ETA: 0s - loss: 0.8446Restoring model weights from the end of the best epoch: 147.\n",
+            "30/30 [==============================] - 0s 6ms/step - loss: 0.9748 - val_loss: 1.7985\n",
+            "Epoch 177: early stopping\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "<ipython-input-46-fc1050e1f4f0>:9: UserWarning: Attempt to set non-positive ylim on a log-scaled axis will be ignored.\n",
+            "  plt.ylim((0, 10))\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 640x480 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjoAAAHHCAYAAAC2rPKaAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAC/+ElEQVR4nOydd5wTZf7HP0l2s733ZRcWlqU3qQIqICiigr17VvRULFjvvN95yumdp57lVOxnuVPPLlakCShI771uARa295ZNMr8/nnlmnplM2vbNft+vF68kk8nkSSHz2c+3mSRJkkAQBEEQBBGAmDt7AQRBEARBEO0FCR2CIAiCIAIWEjoEQRAEQQQsJHQIgiAIgghYSOgQBEEQBBGwkNAhCIIgCCJgIaFDEARBEETAQkKHIAiCIIiAhYQOQRAEQRABCwkdok154oknYDKZOnsZrSYrKws33XRTZy+DaAUmkwlPPPGE34/Ly8uDyWTC+++/73G/999/HyaTCZs3b/a4X0v+TwTK/6O2ZurUqZg6dWqLHuvr/+mWfm+IrgsJHYIgCIIgApagzl4AQXRFDhw4ALOZ/g4gCILo7pDQIQgDQkJCOnsJBEEQRBtAf7ISLWbNmjUYN24cQkNDkZ2djTfffNPtvh9++CHGjBmDsLAwxMfH4+qrr8axY8c0+0ydOhXDhg3Dzp07MWXKFISHh6N///744osvAACrV6/GhAkTEBYWhoEDB2L58uUuz7Nt2zbMmjUL0dHRiIyMxPTp07F+/Xq/X5s+nt/c3IwFCxYgJycHoaGhSEhIwBlnnIFly5ZpHvfzzz/jzDPPREREBGJjY3HRRRdh3759mn1qamowf/58ZGVlISQkBMnJyTjnnHOwdetWzX4bNmzA+eefj7i4OERERGDEiBH417/+pdy/c+dO3HTTTejXrx9CQ0ORmpqKW265BWVlZZrj8HyP/fv348orr0R0dDQSEhJw3333obGx0eW1+/JZeYPnr6xZswb33nsvkpKSEBsbi9///vew2WyorKzEDTfcgLi4OMTFxeGRRx6BJEmaY9TV1eHBBx9EZmYmQkJCMHDgQPzzn/902a+pqQn3338/kpKSEBUVhTlz5uD48eOG6zpx4gRuueUWpKSkICQkBEOHDsW7777r12vzREVFBcaPH4+MjAwcOHCgzY4LAHa7HU8++SSys7MREhKCrKws/OlPf0JTU5Nmv82bN2PmzJlITExEWFgY+vbti1tuuUWzzyeffIIxY8YgKioK0dHRGD58uOa7ZQTPXfrnP/+JhQsXol+/fggPD8e5556LY8eOQZIkPPnkk8jIyEBYWBguuugilJeXuxzntddew9ChQxESEoL09HTMmzcPlZWVLvu99dZbyM7ORlhYGMaPH49ff/3VcF1NTU14/PHH0b9/f4SEhCAzMxOPPPKIy/vSGnz5XfHlN+LUqVO4+eabkZGRgZCQEKSlpeGiiy5CXl5em62VcIUcHaJF7Nq1C+eeey6SkpLwxBNPwG634/HHH0dKSorLvn/729/w2GOP4corr8TcuXNRUlKCV155BWeddRa2bduG2NhYZd+KigpceOGFuPrqq3HFFVfg9ddfx9VXX42PPvoI8+fPxx133IFrr70Wzz33HC6//HIcO3YMUVFRAIA9e/bgzDPPRHR0NB555BEEBwfjzTffxNSpUxWR1FKeeOIJPP3005g7dy7Gjx+P6upqbN68GVu3bsU555wDAFi+fDlmzZqFfv364YknnkBDQwNeeeUVTJ48GVu3bkVWVhYA4I477sAXX3yBu+++G0OGDEFZWRnWrFmDffv2YfTo0QCAZcuW4cILL0RaWhruu+8+pKamYt++ffj+++9x3333KfscPXoUN998M1JTU7Fnzx689dZb2LNnD9avX++SzHrllVciKysLTz/9NNavX4+XX34ZFRUV+M9//tOiz8oX7rnnHqSmpmLBggVYv3493nrrLcTGxuK3335D79698fe//x0//vgjnnvuOQwbNgw33HADAECSJMyZMwcrV67ErbfeilGjRmHJkiV4+OGHceLECbz44ovKc8ydOxcffvghrr32WkyaNAk///wzLrjgApe1FBUV4fTTT4fJZMLdd9+NpKQkLF68GLfeeiuqq6sxf/58v16bntLSUpxzzjkoLy/H6tWrkZ2d3arj6Zk7dy4++OADXH755XjwwQexYcMGPP3009i3bx++/vprAEBxcbHy//KPf/wjYmNjkZeXh6+++ko5zrJly3DNNddg+vTpeOaZZwAA+/btw9q1a5Xvlic++ugj2Gw23HPPPSgvL8ezzz6LK6+8EmeffTZWrVqFP/zhDzh8+DBeeeUVPPTQQxoh+cQTT2DBggWYMWMG7rzzThw4cACvv/46Nm3ahLVr1yI4OBgA8O9//xu///3vMWnSJMyfPx9Hjx7FnDlzEB8fj8zMTOV4TqcTc+bMwZo1a3D77bdj8ODB2LVrF1588UUcPHgQixYtavX77uvvii+/EZdddhn27NmDe+65B1lZWSguLsayZctQUFCg/D4Q7YBEEC3g4osvlkJDQ6X8/Hxl2969eyWLxSKJX6u8vDzJYrFIf/vb3zSP37VrlxQUFKTZPmXKFAmA9PHHHyvb9u/fLwGQzGaztH79emX7kiVLJADSe++9p1mT1WqVjhw5omwrLCyUoqKipLPOOsuv19enTx/pxhtvVG6PHDlSuuCCCzw+ZtSoUVJycrJUVlambNuxY4dkNpulG264QdkWExMjzZs3z+1x7Ha71LdvX6lPnz5SRUWF5j6n06lcr6+vd3ns//73PwmA9MsvvyjbHn/8cQmANGfOHM2+d911lwRA2rFjhyRJ/n1W3njvvfckANLMmTM1a544caJkMpmkO+64Q/N6MzIypClTpijbFi1aJAGQnnrqKc1xL7/8cslkMkmHDx+WJEmStm/fLgGQ7rrrLs1+1157rQRAevzxx5Vtt956q5SWliaVlpZq9r366qulmJgY5f3Mzc11+W55eo2bNm2STp48KQ0dOlTq16+flJeXp9mPv//+oH8Mf51z587V7PfQQw9JAKSff/5ZkiRJ+vrrr5U1ueO+++6ToqOjJbvd7tea+PuSlJQkVVZWKtsfffRRCYA0cuRIqbm5Wdl+zTXXSFarVWpsbJQkSZKKi4slq9UqnXvuuZLD4VD2e/XVVyUA0rvvvitJkiTZbDYpOTlZGjVqlNTU1KTs99Zbb0kANN+T//73v5LZbJZ+/fVXzVrfeOMNCYC0du1aZZv+/7Q79N8bX39XvP1GVFRUSACk5557zusaiLaFQleE3zgcDixZsgQXX3wxevfurWwfPHgwZs6cqdn3q6++gtPpxJVXXonS0lLlX2pqKnJycrBy5UrN/pGRkbj66quV2wMHDkRsbCwGDx6scWT49aNHjyprWrp0KS6++GL069dP2S8tLQ3XXnst1qxZg+rq6ha/5tjYWOzZsweHDh0yvP/kyZPYvn07brrpJsTHxyvbR4wYgXPOOQc//vij5lgbNmxAYWGh4bG2bduG3NxczJ8/38VBEV2asLAw5XpjYyNKS0tx+umnA4BLGAwA5s2bp7l9zz33AICyNn8/K1+49dZbNWueMGECJEnCrbfeqmyzWCwYO3as8lnyNVksFtx7772a4z344IOQJAmLFy/WrF2/n96dkSQJX375JWbPng1JkjSvb+bMmaiqqjJ8z3zh+PHjmDJlCpqbm/HLL7+gT58+LTqOJ/jrfOCBBzTbH3zwQQDADz/8AADK9+X7779Hc3Oz4bFiY2NRV1fnEnb1lSuuuAIxMTHKbf5/8frrr0dQUJBmu81mw4kTJwAwx9Nms2H+/PmaRP/bbrsN0dHRymvYvHkziouLcccdd8BqtSr73XTTTZrnBYDPP/8cgwcPxqBBgzSf6dlnnw0ALfrOivjzu+LtNyIsLAxWqxWrVq1CRUVFq9ZF+AcJHcJvSkpK0NDQgJycHJf7Bg4cqLl96NAhSJKEnJwcJCUlaf7t27cPxcXFmv0zMjJcQi4xMTEau5pvA6D8YJSUlKC+vt7l+QEmwJxOp995JiJ//etfUVlZiQEDBmD48OF4+OGHsXPnTuX+/Px8AK6vnz9/aWkp6urqAADPPvssdu/ejczMTIwfPx5PPPGE5iR/5MgRAMCwYcM8rqm8vBz33XcfUlJSEBYWhqSkJPTt2xcAUFVV5bK//vPKzs6G2WxW8gP8/ax8QRTCgPq5GX2e4o9/fn4+0tPTlbAkZ/Dgwcr9/NJsNruEifSfQ0lJCSorK/HWW2+5vLabb74ZAFr0+gDgd7/7HYqLi7F69Wr06tWrRcfwBn+d/fv312xPTU1FbGys8n5MmTIFl112GRYsWIDExERcdNFFeO+99zT5KnfddRcGDBiAWbNmISMjA7fccgt++uknn9fiz2cKqP9H3f0fsVqt6Nevn+YzBVy/r8HBwRqxAbDv7J49e1w+0wEDBgBo+WfK8ed3xdtvREhICJ555hksXrwYKSkpOOuss/Dss8/i1KlTrVoj4R3K0SHaFafTCZPJhMWLF8NisbjcHxkZqblttI+n7ZIuMbW9OOuss3DkyBF88803WLp0Kd555x28+OKLeOONNzB37ly/jnXllVfizDPPxNdff42lS5fiueeewzPPPIOvvvoKs2bN8us4v/32Gx5++GGMGjUKkZGRcDqdOO+88+B0Or0+Xi8o/f2sfMGfz7M9P0v+flx//fW48cYbDfcZMWJEi4596aWX4j//+Q/+9a9/4emnn27xGn3BWxNBk8mEL774AuvXr8d3332HJUuW4JZbbsHzzz+P9evXIzIyEsnJydi+fTuWLFmCxYsXY/HixXjvvfdwww034IMPPvC6hq70f9TpdGL48OF44YUXDO/Xi6/2xJffiPnz52P27NlYtGgRlixZgsceewxPP/00fv75Z5x22mkdttaeBgkdwm+SkpIQFhZmaNHqK02ys7MhSRL69u2r/JXVXmsKDw83rHTZv38/zGZzq3/04uPjcfPNN+Pmm29GbW0tzjrrLDzxxBOYO3euEq5w9/yJiYmIiIhQtqWlpeGuu+7CXXfdheLiYowePRp/+9vfMGvWLMWd2L17N2bMmGG4loqKCqxYsQILFizAX/7yF2W7O9uc38cdHwA4fPgwnE6nkgTZUZ+VL/Tp0wfLly9HTU2NxtXZv3+/cj+/dDqdOHLkiOavbv3nwCuyHA6H2/e0pdxzzz3o378//vKXvyAmJgZ//OMf2/T4gPo6Dx06pLhaAEuwrqysdAmXnX766Tj99NPxt7/9DR9//DGuu+46fPLJJ8oJ12q1Yvbs2Zg9ezacTifuuusuvPnmm3jsscdcXKO2fA0A+2xEZ8ZmsyE3N1f5XPh+hw4dUkJQAKtqys3NxciRI5Vt2dnZ2LFjB6ZPn94unaT9/V3x9BshrvnBBx/Egw8+iEOHDmHUqFF4/vnn8eGHH7b5+gkGha4Iv7FYLJg5cyYWLVqEgoICZfu+ffuwZMkSzb6XXnopLBYLFixY4PKXnSRJLqXQrVnTueeei2+++UZTqllUVISPP/4YZ5xxBqKjo1t8fP06IyMj0b9/fyUkkJaWhlGjRuGDDz7QlMru3r0bS5cuxfnnnw+Axfz1YaXk5GSkp6crxxo9ejT69u2Ll156yaXslr+H/K9n/Xv60ksvuX0NCxcu1Nx+5ZVXAEBxkTrqs/KF888/Hw6HA6+++qpm+4svvgiTyaSsmV++/PLLmv3074PFYsFll12GL7/8Ert373Z5vpKSklat97HHHsNDDz2ERx99FK+//nqrjmUE//7oXxd3MniVWUVFhctnN2rUKABQvl/6z9FsNituVluWZOuZMWMGrFYrXn75Zc0a//3vf6Oqqkp5DWPHjkVSUhLeeOMN2Gw2Zb/333/f5f/DlVdeiRMnTuDtt992eb6GhgYlXNxS/Pld8fYbUV9f79LOITs7G1FRUe36vhPk6BAtZMGCBfjpp59w5pln4q677oLdbscrr7yCoUOHauLS2dnZeOqpp/Doo48iLy8PF198MaKiopCbm4uvv/4at99+Ox566KE2WdNTTz2FZcuW4YwzzsBdd92FoKAgvPnmm2hqasKzzz7bqmMPGTIEU6dOxZgxYxAfH4/NmzcrJeKc5557DrNmzcLEiRNx6623KuXlMTExyuycmpoaZGRk4PLLL8fIkSMRGRmJ5cuXY9OmTXj++ecBsBPP66+/jtmzZ2PUqFG4+eabkZaWhv3792PPnj1YsmQJoqOjlRh/c3MzevXqhaVLlyI3N9fta8jNzcWcOXNw3nnnYd26dUpJNv8LuSM/K2/Mnj0b06ZNw//93/8hLy8PI0eOxNKlS/HNN99g/vz5ius1atQoXHPNNXjttddQVVWFSZMmYcWKFTh8+LDLMf/xj39g5cqVmDBhAm677TYMGTIE5eXl2Lp1K5YvX27Y88UfnnvuOVRVVWHevHmIiorC9ddf36rjiYwcORI33ngj3nrrLVRWVmLKlCnYuHEjPvjgA1x88cWYNm0aAOCDDz7Aa6+9hksuuQTZ2dmoqanB22+/jejoaEUszZ07F+Xl5Tj77LORkZGB/Px8vPLKKxg1apTGLWprkpKS8Oijj2LBggU477zzMGfOHBw4cACvvfYaxo0bp7xfwcHBeOqpp/D73/8eZ599Nq666irk5ubivffec8nR+d3vfofPPvsMd9xxB1auXInJkyfD4XBg//79+Oyzz7BkyRKMHTu2Vev29XfF22/EwYMHMX36dFx55ZUYMmQIgoKC8PXXX6OoqEhTgEG0Ax1c5UUEEKtXr5bGjBkjWa1WqV+/ftIbb7zhtpT2yy+/lM444wwpIiJCioiIkAYNGiTNmzdPOnDggLLPlClTpKFDh7o8tk+fPoZlmwBcyrS3bt0qzZw5U4qMjJTCw8OladOmSb/99pvfr01fivrUU09J48ePl2JjY6WwsDBp0KBB0t/+9jfJZrNpHrd8+XJp8uTJUlhYmBQdHS3Nnj1b2rt3r3J/U1OT9PDDD0sjR46UoqKipIiICGnkyJHSa6+95rKGNWvWSOecc46y34gRI6RXXnlFuf/48ePSJZdcIsXGxkoxMTHSFVdcIRUWFrqUx/LPZO/evdLll18uRUVFSXFxcdLdd98tNTQ0uDyvL5+VN8TSaxG+lpKSEs32G2+8UYqIiNBsq6mpke6//34pPT1dCg4OlnJycqTnnntOU64uSZLU0NAg3XvvvVJCQoIUEREhzZ49Wzp27JjL+yBJklRUVCTNmzdPyszMlIKDg6XU1FRp+vTp0ltvvaXs05Lyco7D4ZCuueYaKSgoSFq0aJHmNfuD0WOam5ulBQsWSH379pWCg4OlzMxM6dFHH1XKtyWJff+vueYaqXfv3lJISIiUnJwsXXjhhdLmzZuVfb744gvp3HPPlZKTkyWr1Sr17t1b+v3vfy+dPHnS45r4+6Ivj165cqUEQPr888+9vj+SxMrJBw0aJAUHB0spKSnSnXfe6dJGQZIk6bXXXpP69u0rhYSESGPHjpV++eUXacqUKZryckli5ejPPPOMNHToUCkkJESKi4uTxowZIy1YsECqqqpS9mtpebkk+fa74u03orS0VJo3b540aNAgKSIiQoqJiZEmTJggffbZZ17XRLQOkyR1UDYnQRCdAm/SVlJSgsTExM5eDkEQRIdCOToEQRAEQQQsAZGjc8kll2DVqlWYPn26MheJIIzw1rMiLCzMpSkZodLQ0GDYo0ckPj5e0+iNUKmqqkJDQ4PHfVJTUztoNQTRMwgIoXPffffhlltu8akHBNGzSUtL83j/jTfeiPfff79jFtMN+fTTT5UGe+5YuXIlpk6d2jEL6mbcd999Xn+nKJuAINqWgMnRWbVqFV599VVydAiPGE08F0lPT8eQIUM6aDXdj5MnT2LPnj0e9xkzZgzi4uI6aEXdi71797od/cFp6z4/BNHT6XRH55dffsFzzz2HLVu24OTJk/j6669x8cUXa/ZZuHAhnnvuOZw6dQojR47EK6+8gvHjx3fOgoluDZ1EWkdaWppXV4xwz5AhQ0hIE0QH0+nJyHV1dRg5cqRLMzPOp59+igceeACPP/44tm7dipEjR2LmzJmtnmFCEARBEETg0+mOzqxZszzO93nhhRdw2223KXkBb7zxBn744Qe8++67LWq13tTUpOlC6XQ6UV5ejoSEhHZpIU4QBEEQRNsjSRJqamqQnp4Os9m9b9PpQscTNpsNW7ZswaOPPqpsM5vNmDFjBtatW9eiYz799NNYsGBBWy2RIAiCIIhO5NixY8jIyHB7f5cWOqWlpXA4HEhJSdFsT0lJUYb7ASzvYseOHairq0NGRgY+//xzTJw40fCYjz76KB544AHldlVVFXr37o1jx461ahYSQRAEQRAdR3V1NTIzMzWDf43o0kLHV7xV0oiEhIQgJCTEZXt0dDQJHYIgCILoZnhLO+n0ZGRPJCYmwmKxoKioSLO9qKiImmoRBEEQBOGVLi10rFYrxowZgxUrVijbnE4nVqxY4TY0RRAEQRAEwen00FVtbS0OHz6s3M7NzcX27dsRHx+P3r1744EHHsCNN96IsWPHYvz48XjppZdQV1fntTsrQRAEQRBEpwudzZs3Y9q0acptnijMW/FfddVVKCkpwV/+8hecOnUKo0aNwk8//eSSoNyeOJ1O2Gy2Dns+wjvBwcGwWCydvQyCIAiiixMwIyBaSnV1NWJiYlBVVWWYjGyz2ZCbmwun09kJqyM8ERsbi9TUVOp/RBAE0QPxdv7mdLqj05WRJAknT56ExWJBZmamx4ZERMchSRLq6+uV7tg0koAgCIJwBwkdD9jtdtTX1yM9PR3h4eGdvRxCICwsDABQXFyM5ORkCmMRBEEQhpBF4QGHwwGAVX8RXQ8uPpubmzt5JQRBEERXhYSOD1AOSNeEPheCIAjCGyR0CIIgCIIIWEjoBCBTp07F/PnzO3sZBEEQBNHpkNAhCIIgCCJg6bFCZ+HChRgyZAjGjRvX2UshCIIgCKKd6LFCZ968edi7dy82bdrU2UtpVyoqKnDDDTcgLi4O4eHhmDVrFg4dOqTcn5+fj9mzZyMuLg4REREYOnQofvzxR+Wx1113HZKSkhAWFoacnBy89957nfVSCIIgCMJvqI+OH0iShIZmR6c8d1iwpUVVRjfddBMOHTqEb7/9FtHR0fjDH/6A888/H3v37kVwcDDmzZsHm82GX375BREREdi7dy8iIyMBAI899hj27t2LxYsXIzExEYcPH0ZDQ0NbvzSCIAiCaDdI6PhBQ7MDQ/6ypFOee+9fZyLc6t/HxQXO2rVrMWnSJADARx99hMzMTCxatAhXXHEFCgoKcNlll2H48OEAgH79+imPLygowGmnnYaxY8cCALKystrmxRAEQRBEB9FjQ1c9gX379iEoKAgTJkxQtiUkJGDgwIHYt28fAODee+/FU089hcmTJ+Pxxx/Hzp07lX3vvPNOfPLJJxg1ahQeeeQR/Pbbbx3+GgiCIAiiNZCj4wdhwRbs/evMTnvu9mDu3LmYOXMmfvjhByxduhRPP/00nn/+edxzzz2YNWsW8vPz8eOPP2LZsmWYPn065s2bh3/+85/tshaCIAiCaGvI0fEDk8mEcGtQp/xrSX7O4MGDYbfbsWHDBmVbWVkZDhw4gCFDhijbMjMzcccdd+Crr77Cgw8+iLffflu5LykpCTfeeCM+/PBDvPTSS3jrrbda9yYSBEEQRAdCjk4Ak5OTg4suugi33XYb3nzzTURFReGPf/wjevXqhYsuuggAMH/+fMyaNQsDBgxARUUFVq5cicGDBwMA/vKXv2DMmDEYOnQompqa8P333yv3EQRBEER3gBydAOe9997DmDFjcOGFF2LixImQJAk//vgjgoODAbDBpfPmzcPgwYNx3nnnYcCAAXjttdcAsGGmjz76KEaMGIGzzjoLFosFn3zySWe+HIIgCILwC5MkSVJnL6Izqa6uRkxMDKqqqhAdHa25r7GxEbm5uejbty9CQ0M7aYWEO+jzIQiC6Ll4On+LkKNDEARBEETAQkKHIAiCIIiAhYQOQRAEQRABCwkdgiAIgiACFhI6BEEQBEEELCR0CIIgCIIIWEjoEARBEAQRsJDQIQiCIAgiYOmxQmfhwoUYMmQIxo0b19lLIQiCIAiineixQmfevHnYu3cvNm3a1NlL6XJkZWXhpZde8mlfk8mERYsWtet6CIIgCKKl9FihQxAEQRBE4ENChyAIgiCIgIWEToDx1ltvIT09HU6nU7P9oosuwi233IIjR47goosuQkpKCiIjIzFu3DgsX768zZ5/165dOPvssxEWFoaEhATcfvvtqK2tVe5ftWoVxo8fj4iICMTGxmLy5MnIz88HAOzYsQPTpk1DVFQUoqOjMWbMGGzevLnN1kYQBEH0PEjo+IMkAba6zvnn45D5K664AmVlZVi5cqWyrby8HD/99BOuu+461NbW4vzzz8eKFSuwbds2nHfeeZg9ezYKCgpa/fbU1dVh5syZiIuLw6ZNm/D5559j+fLluPvuuwEAdrsdF198MaZMmYKdO3di3bp1uP3222EymQAA1113HTIyMrBp0yZs2bIFf/zjHxEcHNzqdREEQRA9l6DOXkC3orke+Ht65zz3nwoBa4TX3eLi4jBr1ix8/PHHmD59OgDgiy++QGJiIqZNmwaz2YyRI0cq+z/55JP4+uuv8e233yqCpKV8/PHHaGxsxH/+8x9ERLC1vvrqq5g9ezaeeeYZBAcHo6qqChdeeCGys7MBAIMHD1YeX1BQgIcffhiDBg0CAOTk5LRqPQRBEARBjk4Act111+HLL79EU1MTAOCjjz7C1VdfDbPZjNraWjz00EMYPHgwYmNjERkZiX379rWJo7Nv3z6MHDlSETkAMHnyZDidThw4cADx8fG46aabMHPmTMyePRv/+te/cPLkSWXfBx54AHPnzsWMGTPwj3/8A0eOHGn1mgiCIIieDTk6/hAczpyVznpuH5k9ezYkScIPP/yAcePG4ddff8WLL74IAHjooYewbNky/POf/0T//v0RFhaGyy+/HDabrb1WruG9997Dvffei59++gmffvop/vznP2PZsmU4/fTT8cQTT+Daa6/FDz/8gMWLF+Pxxx/HJ598gksuuaRD1kYQBEEEHiR0/MFk8il81NmEhobi0ksvxUcffYTDhw9j4MCBGD16NABg7dq1uOmmmxTxUFtbi7y8vDZ53sGDB+P9999HXV2d4uqsXbsWZrMZAwcOVPY77bTTcNppp+HRRx/FxIkT8fHHH+P0008HAAwYMAADBgzA/fffj2uuuQbvvfceCR2CIAiixVDoKkC57rrr8MMPP+Ddd9/Fddddp2zPycnBV199he3bt2PHjh249tprXSq0WvOcoaGhuPHGG7F7926sXLkS99xzD373u98hJSUFubm5ePTRR7Fu3Trk5+dj6dKlOHToEAYPHoyGhgbcfffdWLVqFfLz87F27Vps2rRJk8NDEARBEP5Cjk6AcvbZZyM+Ph4HDhzAtddeq2x/4YUXcMstt2DSpElITEzEH/7wB1RXV7fJc4aHh2PJkiW47777MG7cOISHh+Oyyy7DCy+8oNy/f/9+fPDBBygrK0NaWhrmzZuH3//+97Db7SgrK8MNN9yAoqIiJCYm4tJLL8WCBQvaZG0EQRBEz8QkST7WLQco1dXViImJQVVVFaKjozX3NTY2Ijc3F3379kVoaGgnrZBwB30+BEEQPRdP528RCl0RBEEQBBGwkNAh3PLRRx8hMjLS8N/QoUM7e3kEQRAE4RXK0SHcMmfOHEyYMMHwPupYTBAEQXQHSOgQbomKikJUVFRnL4MgCIIgWgyFrnygh+drd1nocyEIgiC8QULHAxaLBQA6rGsw4R/19fUAKIxGEARBuKfHhq4WLlyIhQsXwuFwuN0nKCgI4eHhKCkpQXBwMMxm0oVdAUmSUF9fj+LiYsTGxiqClCAIgiD0UB8dL3X4NpsNubm5bdY9mGg7YmNjkZqaCpPJ1NlLIQiCIDoYX/vo9FhHx1esVitycnIofNXFCA4OJieHIAiC8AoJHR8wm83UeZcgCIIguiGUdEIQBEEQRMBCQocgCIIgiICFhA5BEARBEAELCR2CIAiCIAIWEjoEQRAEQQQsJHQIgiAIgghYSOgQBEEQBBGwkNAhCIIgCCJgIaFDEARBEETAQkKHIAiCIIiAhYQOQRAEQRABCwkdgiAIgiACFhI6BEEQBEEELCR0CIIgCIIIWEjoEARBEAQRsJDQIQiCIAgiYCGhQxAEQRBEwEJChyAIgiCIgKXHCp2FCxdiyJAhGDduXGcvhSAIgiCIdsIkSZLU2YvoTKqrqxETE4OqqipER0d39nIIgiAIgvABX8/fPdbRIQiCIAgi8CGhQxAEQRBEwEJChyAIgiCIgIWEDkEQBEEQAQsJHYIgCIIgAhYSOgRBEARBBCwkdAiCIAiCCFhI6BAEQRAEEbCQ0CEIgiAIImAhoUMQBEEQRMBCQocgCIIgiICFhA5BEARBEAELCR2CIAiCIAIWEjoEQRAEQQQsJHQIgiAIgghYSOgQBEEQBBGwkNAhCIIgCCJgIaFDEARBEETAQkKHIAiCIIiAhYQOQRAEQRABCwkdgiAIgiACFhI6BEEQBEEELCR0CIIgCIIIWEjoEARBEAQRsJDQIQiCIAgiYOmxQmfhwoUYMmQIxo0b19lLIQiCIAiinTBJkiR19iI6k+rqasTExKCqqgrR0dGdvRyCIAiCIHzA1/N3j3V0CIIgCIIIfEjoEARBEAQRsJDQIQiCIAgiYCGhQxAEQRBEwEJChyAIgiCIgIWEDkEQBEEQAQsJHYIgCIIgAhYSOgRBEARBBCwkdAiCIAiCCFhI6BAEQRAEEbCQ0CEIgiAIImAhoUMQBEEQRMBCQocgCIIgiICFhA5BEARBEAELCR2CIAiCIAIWEjoEQRAEQQQsJHQIgiAIgghYSOgQBEEQBBGwkNAhCIIgCCJgIaFDEARBEETAQkKHIAiCIIiAhYQOQRAEQRABCwkdgiAIgiACFhI6BEEQBEEELCR0CIIgCIIIWEjoEARBEAQRsJDQIQiCIAgiYCGhQxAEQRBEwEJChyAIgiCIgIWEDkEQBEEQAUuPFToLFy7EkCFDMG7cuM5eCqFHkoCyI4DT2dkrIQiCILo5JkmSpM5eRGdSXV2NmJgYVFVVITo6urOXQwDA9o+BRXcC5zwJTL63s1dDEARBdEF8PX/3WEeH6MKUHmKXZYc7dx0EQRBEt4eEDtH1sDexS4etc9dBEARBdHtI6BBdD3uj9pIgCIIgWggJHaLrwR0dOzk6BEEQROsgoUN0PbiT42jq3HUQBEEQ3R4SOkTXQwldkdAhCIIgWgcJHaLrwZOQSegQBEEQrYSETnsgScDq54AfHgIaqzp7Nd0PCl0RBEEQbQQJnfbAZALWvQpsehuoPtnZq+l+UDIyQRAE0UaQ0GkvIlPYZW1R566jO0Ll5QRBEEQbQUKnvYhMZpe1xZ27ju4INQwkCIIg2ggSOu0FOToth6quCIIgiDaChE57EZXKLkno+I+dqq4IgiCItoGETntBoauWQ1VXBEEQRBtBQqe9UEJXpzp3Hd0RMUdHkjp3LQRBEES3hoROe0GOTssRq60oIZkgCIJoBSR02gtKRm4ZDjsgOdTbVGJOEARBtAISOu0FFzr1ZYCjuXPX0p3QCxtqGkgQBEG0AhI67UVYPGCysOt1JZ27lu6EPlRFCckEQRBEKyCh016YzUKeDoWvfMbF0SGhQxAEQbQcEjrtiZKnQwnJPhNoQqeuFNj9FVCR39krIQiC6JEEdfYCAhoudGqoxNxn9MKmu4au8n8DVj8L5P7Ckqv7ngXc+F1nr4ogCKLHQUKnPelqJeaSxCard2UCJRn5+/uBkv3q7aoTnbcWgiCIHgyFrtqTrlJi7rADb04B3p7W9SvA9I5Odywvt9uA0kPs+oUvydu64esgCIIIAEjotCddRehU5gMntwOF24CDP3XuWrzhErrqho5O+REWrrJGAZkT2Lbmhs5dE0EQRA+FhE570lVCV2VH1OtbPui8dfiCi6PTDXN0Sg6wy6QBQHAYu06ODkEQRKdAQqc96SqOTvlR9frh5UBlQeetxRt6QdAdk5G50EkcqBU6NLeLIAiiwyGh055EdZHyclHoQAK2fdhpS/FKIDg6pYKjExTCrkvOrp8fRRAEEYCQ0GlPIuTQVXMd0FTbeevgQqfvWexy24eA0+F+/5Ziqwc2vNW6CqNA6KNTcpBdJg0CgsLU7XbK0yEIguhoSOi0JyGRgDWSXe/M8BUXOpPuY6Mpqk+wEFZbs/0jYPHDwKqnW34Ml9BVN0tGdjqAMrniKpE7OnJJfzPl6RAEQXQ0JHTam84eA+Gws6orAEgeDAy/gl0/uKTtn6toD7usbo2j46a83G5jidRdOb8IYOuzNwKWECAui/UtCgpl95GjQxAE0eGQ0GlvOjshuaoAcNrZyTYqjZ18AaChou2fq+wwu6wvb/kx9MnHvGHggR+B7+4Flv7Z+zHsNsDpbPkaWkOpHLZK6A+Y5aGuwbLQIUeHIAiiwyGh0950VIl5U62aGyLCw1Zxfdmg0dBoef/qtl8Db5LX0Aqh424EBH//NInVBtjqgZdHAf+Z0/I1tAbeDTlpoLotiErMCYIgOgsSOu1NRzk6i/8ALBzHZiuJlOeyy/h+7DJEFjqNbSx0GquBWnmmV30r3CJ3ycjNdeyy+qTnx5cfYaGz/LWdU86tJCKLQkeuvCKhQxAE0eGQ0GlvOkroFG5jl3u/1W7nzQITZKHTXo5OudCU0FbT8lJqd+XlNlno1Jd6rsSqL2OXkhOwdUKlGy8tTxygbuO9dKg7MkEQRIdDQqe9ieygXjpcSB1dpd3OQz16R6eppm2fv/Sw9nZLc4C462EOZpc8dGWrV/fxNA2+rlS93ljVsjW0FEly4+jwZGRydAiCIDoaEjrtTUc4Oo5m1ckoOwRUHVfv0wud0Bh22dahK15SzWlpQjJ3a7jzxJOReegK8Cx0+PsAtP1r9EZtEdBUBZjMLBmZQ44OQRBEp0FCp73hycg17Sh06koBCPkoR1ezS6cDqMhj1/WOjq2mbZsGlukdnVYKHb5OQ0en0P3jO9PR4aMf4vqqeTkAOToEQRCdCAmd9oY7OnUlLRMWNUXee8fU6hwOHr6qOg44m1lPl+gMto07JUDbhq9K28vR0eXoAJ4TkusFoeMtD+nULmDPIr+X6JYKOfFbdHMAGuxJEATRiZDQaW8iEgGYAMnh/8nf6QTenga8Nkl7otfD83/MQezy6CqWL8IThOOyWGk5wJwGi+w2tFVCsiSpSc9xfdllix0dWQyE6ISOJnTVRo7Ol3OBz290FWkthT9fWJx2O3d3qI8OQRBEh9MiofPBBx/ghx9+UG4/8sgjiI2NxaRJk5Cfn99mi2tPFi5ciCFDhmDcuHHt+0SWYCA8gV33N0+nMo+VSttqgMpj6vZTu4BdX6i3+XH7TGY9W+qKgeJ9rvk5nNA2LjGvOcmEiMkC9BrNtrXa0ZFziYxCVx4dHTFHx4vQ4blMNV5K1n2Fv5+iawYIfXQoR4cgCKKjaZHQ+fvf/46wMPbjvW7dOixcuBDPPvssEhMTcf/997fpAtuLefPmYe/evdi0aVP7P1lLE5KL9qrX64SqrS9vA768FTi5U3vc2EygzyR2fdt/VTGkFzohbVxizh2RuCz1tbbW0eFCxyh01RZVV45mtfy8rUJ4/P3ka+dQZ2SCIIhOo0VC59ixY+jfn+UhLFq0CJdddhluv/12PP300/j111/bdIEBQVQLS8z57CjxsZKk5oLw5Fd+X2QK0G8qu77+NaBgHbveb4r2uHpHx94EbHhTDT/5izLEMocNDQVa7+i0NHRV76PQEe/zJnRO7gC+vcezwALU9zNE7+jQrCuCIIjOokVCJzIyEmVlLESwdOlSnHPOOQCA0NBQNDTQj7kLLXV0igWhU1fCLpuqVdeDV1Tx40amADnnsvJmAMiZCfz+F2DATO1x9Y7O/u+BxY8AS/7Pv/VxlKaE/YFwOT+lpX10eKgqJEq+LZeX60NXRl2Pnbo8KE+OVUOlsJ8XobNuIbD1P8DOzzzv1+QmdKWUl5Oj48LR1cCLw4HDyzt7JQRBBChBLXnQOeecg7lz5+K0007DwYMHcf755wMA9uzZg6ysrLZcX2DgaYJ5QwVQuJ05MSaT9j4xdMUfK5apK0KHOzrJQPIg4KYfWbgk/TTj9SiOjuxq8Pyf4r3G+3uDh64S+qthmxY7Om5CV82C0LE3AI2Vrkm/DZXQlNl7dHQq1eveQng8HOZNqPLnc+vokNBxYf/3bPDs/h+B/jM6ezUEQQQgLXJ0Fi5ciIkTJ6KkpARffvklEhJYsu2WLVtwzTXXtOkCAwJPjs6KvwL/vRjY+al2e3ODdqxCrezoiKXkLo5OKrvsM9G9yAGAEFlE8BM8D/dUHVMb9PlDmSB0wuXQVWv76Ijl5ZIk5OjIYtAojCSGrQCt0Fm+APjhQdUJ0ggdL44O35e7am73c5eMTELHLfy72x5DZgmCINBCRyc2Nhavvvqqy/YFCxa0ekEBiacxEMX72OW+74CRV6vbSw6weU0cnowsHsPI0fEFfY5OnTAfqiIPSBpg+DBDHHa1z09Cf1UMtHYEhNgwsLkBilMTm8mer7oQSB6sfWydXujIr6+5AVjzArt+1sNAVKo2dOWt+ozv603oNHFHx10yMoV1XeDf3Y7uYt2d2fYhsPLvwLWfAanDOns1BNHlaZGj89NPP2HNmjXK7YULF2LUqFG49tprUVHRisnVgYqn0BX/oc/9RTsIk4eReL4N3090MqpPsBARrx7igsob+hwd0Qkp9zMhub6UCSSTmb1OHk6qL2/Z9HCjERBi2Co+m10alYTz18HfM+7oiOKQiyF/HB0u2vRCSo/i6OiEjlJeTo6OC+To+M/+H9n//Twq/CAIX2iR0Hn44YdRXc1+mHbt2oUHH3wQ559/PnJzc/HAAw+06QIDAk+hK34SbqoGTmxRt/OKq15j2GWdQegKkvqY4AggJNK39fBEX8XREZwK/SgHb/D1hycAZosaunI2+z89XJIMcnQa1bBVUCgQ04tdN+qlw4VIjNwFusng9XEx5GsysiSpgsmT0JEkD8nIVF7uFsXR6eBxHd0ZXoEo/gFAEIRbWiR0cnNzMWTIEADAl19+iQsvvBB///vfsXDhQixevLhNFxgQcKHTWKU92dnqWTNAzuEV6nXu6PSbxi7rStjJVB/+OrZBfg4fw1aAeiJu0oWuAP9LzLmIiJCfPzhc7bzsb0Ky6GiFCA0DudCxRgBRaey6oaMjvw7u+hg5OnwfXx2dphrW1RpQPwMjbLVqqNElGZkcHUNsdaoYptCV7/AQKIVCCcInWiR0rFYr6uvZXxPLly/HueeeCwCIj49XnB5CIDRGPfmLjf/qdKLlyM/qde7o8B44Dhs7OSuhKzkpVxE6PoatAPVE3NgGoSsudCKT5GWZWp6QLAoB7joBqmAJ9iJ0uOPCGyTaG1koTHyfufjSODoevrOiIHI2u3ce+HtpDlLLyTl8BAQJHS2iAKXQle/wVgskdAjCJ1okdM444ww88MADePLJJ7Fx40ZccMEFAICDBw8iIyOjTRcYEJhMxgnJvJLKKoecCreyE3FdmRrmShuluhu1JerjeSLucTl01VJHx1antcDLjho/pr4cWP0c8Pxg4KMrhNcgrydCeP6WNg3k+TniGgFVMFnDgeh0dr3aoGkgF2zxfaEIwcZq9X0G/M/REQWR+Hg9/EQdEu3aJkDpo0MnJg16oePr0NvcX4Fv5rU84b27w0NXnubfEQSh0CKh8+qrryIoKAhffPEFXn/9dfTqxfImFi9ejPPOO69NFxgwcCEiJhNzpyFpIJA0mIU+clerjQLjsljeDXdL6orVHJ3M8eyS/+j55ejIwqmxWjhxyyfn6uOuJ+Q9i4AXhgArn2JdiQ8tVUVJnUHFl+Lo+Hki4o6HRRg8CqiCKTicVUwBnh2diGQhD6lK5+jIoStfc3T0r8Fd5ZW70nKAysvdoc9Z83UUx5oXWeXRgZ/afk3dAXJ0CMIvWlRe3rt3b3z//fcu21988cVWLyhgMUpI5tcjkoHMfkDJPvYDzh2A5KHq/WWH2RBKfuLNnABsed/1+L6gODo1qgsSnc7yJRqrgPJcIIXlYMHpAJb+mTXpSx3Oyt4dNuaoxPdV3ZKIJPX4YuWVP3DxFBTKpq2bg1m4iL9mawQQJTs6tcUsp8cSrD6ei5iIBBYubKpmJd+GOTo+joAQnR/AtVePcgw3FVcAOTrucBE61UBYrPfH8c+kpyYwKzk6lIxMEL7QIqEDAA6HA4sWLcK+fawPzNChQzFnzhxYLJY2W1xAoZSYG4SuIpOB/mcD6xdqW+FnjJXvl0VE0W52abG6NgT0J3QllpfzNYQnMLFUuJXl6XChc3QVayQYGgPcugx4fRKbil59ggkdj45OC3N0eE5LUAhg0wmdiCSWB+O0s/eSV2EBqqMTnijkIVUZV12JAsbRxERWkOAicVxCV+4cHTddkQFydNyhT6z3NSGZC9O2Gsba3VCqrkg4E4QvtEjoHD58GOeffz5OnDiBgQMHAgCefvppZGZm4ocffkB2dnabLjIg8OToRCYDfc4AMsax0FbWmWwkxNBL2P08/+XULvVYsX20x+chHV9QwisSUJkvP0cSEyiFW7WVV9v+yy6HX8mciehestCRc2RqdVVXQMtzdPicK43QqVUFU3A4c3oiU1mIreakKnQkSXB0ElVnpVHv6PBkZJ0b0FRjLHT0jo67HB0udDw5OvZGtk59Dk9PRe/o+OrQcIFj64FCx25jIh8gR4cgfKRFQufee+9FdnY21q9fj/h4dlIrKyvD9ddfj3vvvRc//PBDmy4yIDBydOqERN7gUGCum8GGkXqhk8wScyNT1ZwdfxydoFA1LFQuJx9HJAJxfdl1XnlVXw7slz/L0b9jl9G8j80J7WuIFEJXLXZ0dEJHX6ZuDVefq/q41l1pqmavB2DuVKiYhyQ6OmUsHNekFzrV7D3Q46ujIyYj6+GvR3KycFuQ1fgY5UfZ2hJzjO8PNPSOjq+VV9z5afKzT1MgIIobEjoE4RMtEjqrV6/WiBwASEhIwD/+8Q9Mnjy5zRYXUHDHRePoCKErT/D8F+5Y8JlWcVmC0PEjR8dkYq5OfZkqdMITgQTZieOOzs5PWT5O6gggbSTbxqueqk4ATqc2AZjT4qorHrqSQz1cECihq0jt8cVEYb6O4AjmoHDXqq5E68rUlWqdg/AE9j64C4Pw5wiNcQ2DiXhMRhbKze0NxkKnpgh44yzW1fmBvb43fzSi7AgL78X18b5vZ+Li6PggdJwOoeqopwsdCl0RhC+0qOoqJCQENTWuJ4ba2lpYrW7+Wu3pGJaXC6Erj4/V3R8lHysuS90mJgP7AnceuKiJSFQb7ZUdYSGWrXLYavQN6uOUzsSFzLHhzfREN6TFVVf60FWo9jjBsqNjlOwsJiIDqqPDhRwfC+FsZjlHABNF4fL+7oQOF0kJssviS3m5nqAQKFVt7roj//pPFoppqgIqco338YWmWuDtacA707t+J2YuGmMy2aUvoSvxc+qJjo6NHB2C8JcWCZ0LL7wQt99+OzZs2ABJkiBJEtavX4877rgDc+bMaes1BgbivCveXVdptufFjdHfH6kTOuEJ2uojX+DOg5KjkwgkyI32ak8B/7uGlblbQoDhl6uPU0JXx1XRFhavfX4uRFqcjCwLHIssmvWhK+X4Bo5OuCy4uNAplSerRySrQomLu7BYtQzdraNTyS4TvQgdd3OuAOagKQnJBn+FVxYAm9/T3havH9tk/JxGVOarzlP+Wt8f19FIkir0E/qzS3040QiN0OmBTQZFcSOKHqcTOLoaWP8G8MNDwMa3O35tBNFFaZHQefnll5GdnY2JEyciNDQUoaGhmDRpEvr374+XXnqpjZcYIPDQjqOJuQRi+3tvboz+fr3Q8SdsxeHOA09sDE9kAoKHhQ4uZi7ItD+pwgIQhE6hccUVIISuWuvoyJeKoxMhr9XAMeLVVNxZUhwreXZXZJIqgngOUmiMq9CRJN1kc/k6Pxl7y9ExCl0BnuddrXpGzS8CgIp89frHVwH/Psf30RziDLDDbnK+PFGRx9oW2G3+P9YfGitZWBRQRaQvoStR6FDoSr2+8U3gP3OAn/4AbHob+PEhFg4lCKJlQic2NhbffPMNDh48iC+++AJffPEFDh48iK+//hqxsbFtvMQAIThU/Wu/tlh1Q4JCteMOjNALCS5ssqexkMqIq/xfj9554AKh90R2OehC4K71wBnztftxoVNXwvr6AK5CjAuRpirAYfd9TWLDQPGSuyBWWej44+hwVykiWV0X7/4cGqttLAgAPzwAPNsPOCWX8iuOzgB2yZOZ9XgqLwfcz7sqPQTs+Jhd7yPnt3FHp7lBnnkmAYXbjI+rhyeJA8ChZb49RuSHh4Dv7gP2u/bJcsuxTcDOz/x7Hv79D41Rvz8UuvKO2A25uV51h7lzmTJM/a7566gSRIDiczKyt6nkK1euVK6/8MILLV9RIBOZwn7Ma06qYZTIZO/lxsFhgDVKLaflOTpRqcA9m1u2Fv0JmQudK95jIYXY3saPC49n4szeCJzcob4GkdBY9XpDhbYiyxPcRdA7OhxPQsclR0f3+sQ1louhK6F5IgDk/8byjgrWAanD1OfgidqQWChN/5o8JSOLr0UvdDa9w6qxBswC+k9n4SYeThRdnJL9xsfVI3aMLjvEHBoxl8sTjmY13CWGz7zx1Vz2POmn+V4xpuSnpaii1JdQlLhPj3R0xNCnxL5PwWHqezHiKmDzv9nnQYNSCQKAH0Jn2zbf/qI0UY8Q9yQOAEoPsr/OeSgkwksiMicyCSiXT8a86qo16E/I3AkJCnEvcgAmyqLTWZJv4Xa2Tf8aLEFqlVKDgShwh0vVlU7o6JORxb9Y3Tk6nIgkdbo4D2eJjg4XOjz0U5nP8h64yxCewEJyDeXMzdK/JiUZ2SBHB3DfHblgPbsccaW6Fh664usEgOJ9xsfVo58BdmgZMP423x5buE0NjbjrAK1HklgFHsDW7bPQ4WHPFNchs54QhU5PbBioT0BubmDfLe5uhUQK32nhvWqoYO950sCOWSdBdCF8FjqiY0O0kD6TWEigYL364+5rfk1EstDzxs8KKyNER8di9R4+E+FNA5W+PgbriclkIqFot+8/ri59dHQVfEoysg85OnqhE5ms5iNx9ycsVi1Zb6phYQGeEFuRJ58o5NBAaCx73xvKjUWAV0fHoDuyrV7tdp0xThVBlQVMQIhCp+SA8XH1cKET3499RoeX+y50xORld0nXeppq1Pwifbm4J8SKQ/6e+Ru6stUyMWpuUQS+e6If5NlcDyBedXutUcIsO+H9/OQ65lbet913h48gAoQe9AvRBeD5LwXr1eGevrodfL/wBPcN5/xBFDYRSf516+V5Ojx3xsiVyp7GLg8u9f24Lo5OqPZ+pY8Od3Qq1fvEUAjg6qyIOTocvaMjJvJW5KuJyEGhLMeKC8y6EtYDaeljQOUxdrL1NOsKMHZ0Tu5g4isyFYjJAGLlMmtbDRNxotApP6qd7u4OHro6TW7wmPuLb48DgDxR6LhJutYjumq8p5MRPJdE2beloSudi9NcZ7xfoKJ3BPlt0dFRZtkJ72fpQQA68UwQPQQSOh1J6ghWOdRYCeT9yrb5Grri+7VF2ArQOg+8l4yviPOlAGOHaYA8xf7QUuPkXSNcZl3pBJ0+dNVUzfJKANfmiy6OjlB1xdGXl4uJvBX5qpDiz8fdorpSYPkTwG8vA78+L+dHyCdyt8nIBo7OCTm/KmMsE5rBYapQq8zXnpQkh5pw6gnu6OScy74rzfXsL3lvOB1qGA3wXeiIvYz0nY4B9h6+OAz4+vfa7eLn5VfoSid0elpCsl7YcYeH5+hYI13fT7GSUN/pmyB6ACR0OhJLEJA5jl3nJxVfRzfw/fwZ9eAJ8YRsNPrAE7w7MsfIlcqcwMRGQzlw3CBhevdXwIkt2m3uRkBweOhKFDENlewkzU/MXBDqQ0gRSa6CTlNeXq1N5BUb9/Hkav4+VRYAe79h14v2qCECi1UtI9cTbFB1dVzuj8OHtwJqflSFIHT46/WWkNzcoDos0elA/xns+pGfPT8OAE7t1M6O8jV0JTo6NQaOzqmdrEHjzk+BUkG4cUcnohWhK6PbgY7NIEcHcOPo1Kj78PCifnYbQfQASOh0NL0nyVdkB8BX4cKnleunlrcUUQj4m/MTnaG9beRKWYLVE+3Bn7T3ndwJfHEza0rodKrbjYZ6ivA+OjzZGWAhnnreodmkipGgEG3oKyLZQOjEaie56xN5eVVZWKx8DPl92vGJKgpK9nvuiszhr0Xso8MFYMY4dRsf1lq4Tc1BypmpPpcnuFALCmMuVOZ4dpvnUnmCuz7J8tT6uhLXcJMR3hwdUbxs/8h1XzF0ZW9QHTp36F2fnjbY0yUZWb6tODpR2u80oBU35OgQPRASOh1Nn4na274mIw+YCczfDZz9WNusQ8xh0Yd0vKF3dNwJJR6+OrhEu/3YBnZZWyTnDsgojo6bqiteXg5oS8y5O6DvEK04PyZ2n965cgld6YQOryrTOzpiMnJTtSpA3CUiA0IfHfkv8KoTLFRmMmvFK59PdWQFu4zOUO/3VnnFc4yi01goLGUYu120x/PjADU/Z8jF7NJh8y1nRiN0DJKRxRPrjv+pfZXEZGRRIHoLX+nX1ONCVwaOjiSpQkd0dPh7KYpNcnSIHggJnY6m11g2cJHjj5sSm9l2FSYaR8ffHB3B0QmJcR+u6T+DnciL92j7soghK7HSx2UEhCh0TGr4B9AKnTrBHRDhJ9DwBOYCGTo6gtBRQldyYrY7R0e/hmMbtc9nhL4zMs/PSRmqFXA8dMVdmIRsIHkQu+6t8ooLtShZiCYPYq+lrljNiTHC6QQKZEen/3TmCgC+ha8avAgd8cRac5KF0ZwOVSxGpgBmi5po7u1ErA9VdadeOts/Bp4frH5fWoJL6KpebhwoO6Nijg4XhaLYJEeH6IGQ0OlorOFA2ij1dlvl3PiLeFL219EJi1PFiKeqsfB4lqsDaF0dUegUrFOvu4yAEJKRg8O1lWFiibkSBtGthTs6/D0Oi4MiYgAmYMR8Bi4UUobKxy4XHget0MkYB/Q9i13nDpW7iivAddYVD1v1Gqvdj4euOIk5QNJgdt1b5VWNvH7uuFkjgPi+7HqxB1enZD97H4Mj2JR6Jenah4RkXqoPMNGhd1iUE6v8vm9+F/hmHjsxB4er4tPXyqvumqNTdZx1na4pbNloDo5R6Ep5z03sM1e6fZOjQxAACZ3OgYevgsPVv2Q7mtbk6PCmgYD3qrGcc9klz9NprNJWD+WtVXNBPJWX80Rkjtg0UF9azuEnT/76zBbt3C7R0bE3qh2Je5+uO06s9jgA60DLBcjJnfJ+nhwdHrqShYpRfg7g2qwxoT/rgB0a473ySgxdcbho8xS+4u5R+igW+hPL6L0hhq4AV1eHn2QHns8uDy5mISyTBTj/Oea0Ab5XXnFho1TeybedTtZJ2pe8os7gp0fViqnWhNuMQldixZXJJIhG+b2nHB2ih0NCpzPgM42iUv3rX9OWBIezkw3gf9UVoPbS8dYHaNAF7PLoavYjW7gdgMRKn81B7C9cLjA8NQwUwzuALkfHzXBRLjzE7dxB4L1xrEI/Ie5O9NblUfHQVVQqe9+CwoBhl6khJUkun3fXFVl8Tc1ywi2fXaUXOjGZ0LhOCf3ZdySJh688JCTz8vhoofw/2QehUyaLJz7Pyx+ho5+npE9I5ifZPpPUXKOQaOC6z4HTrlf3M+r9YgQXNvw18pP82peAV0azRPGuxqFlwL5v1dutSaDmoSv+/W+uV9+TEPmPJv1YE3J0iB4OCZ3OoP85wIQ7gRkLOm8NJhPrnmsOalmnVH6i8eboJA0EEgey8taDS9SwVe/T1RNfvhy+4kKH5+aIycjBPggd/VoUR8dA6PD7LEFqfx6AvR8ZunASd3RCooAbvgVuWczCctzRUfbzJRm5UQ5BNTCRxUeBKPtZtUKF3++L0OE5RlFGjs5u94/jCeGK0BH6BXlDDF0Bro4OdxBCY4DzngFGXA3cuozlAonwz8NbiTkXQvw1cneE51Od2ul9zR2Jo5lNEgfU72FbODpcjNrqtY4O4JqMrMnR8aGEnyACDBI6nYElCJj1D2DInM5dx+++Bm77uWV5Qv2nM8eF56l4gr/Ofd+qQqfXGPZXPqAmJHvqo6MPXYWLOTpuQleDZjMxx10lQBgREatuE7tER6YyV0VMGA8T9s0cpwq0hGzALFR5+ZSM3MC6KQOswsoouZyHr8zB6vVkWVSd8iBYlNCVUBXHhU7JAfeT5Etb4ejUyyXwMfI6XUJXlewyLBboPQG49E3VCRPxJXTldKgndR6e464FF7v+jKHoCEr2s3EiIdHAmQ+yba1JoOZCh+fVNTdoe+gA2mRkSSJHh+jxkNDpycRmsuTTljDiSuDRE76JtSEXscvDy9XE3V5j1J5CvIeLp6GewW5ydOrL3YeucmYA924Dsiar27hAEsWLKHSi01guT0ymuk0URSKWYK0j46ujUyULnZgM4315iXl8P7YWQA2nHVqqzjwTcTpUR0cUOnF92XvHnSSjx/HGhIl80KwboSNJwLf3Al/9Xs2F4aErLsTc5ei4ew85voSuRIGgD13xyjujXj6dCc9hik4HomQh3hpHh4eu+Pe42YOj47QzISSKm6Zq3zuVc6pPAj8+4ltnboLogpDQIVqOrzO3UoaxE669kZ08TWYmsHpPAGACyo8ANUUGVVeio6NL2jYsL/fBmVJCV7HqNtGJ4SERMZwnJjDrEd0JT1VXYnm5InQyjffllVeiiEofxcr1JQfwyz9dH1NXwu4zmbWhOrNZFSFFu4G6MuCnP6k5QpX5rGdOUKi6Hnehq7pSYOsHwM5PWD5Qc4PqMPD3ocZN6EoUlkaIoSunE9j3nevzc/fGYlU/R8XRkUVZVxM6iqMVp+aDtYWjEyE6OjxHRz6+NRJKnldTtWs40JcO1CI7PgY2vgmseaklKyaIToeEDtH+mExa5ydpELPZw+LU0ErerwZ9dMRkZDeOTl2JmifiS/NFLiLEeV0aR0fezl0VwPNJWszT8dgZWXR0jstrcOPojLgS6DcVmHC7dvvUP7HLHZ+wCiMRXhofmapWMnHEyquvfw+sXwgs+TPbxscyJPRX3SN3jk658JwV+apbYQ5SRZno6EiSeqL3JAIBbehq6wfAp9ezoaki4gmdC19bLROPvMKoM0NXjmbg56e0w1F5d+uwODW01KahqzpXR8dk0r6f+korviZf4eFEsbknQXQjSOgQHQMPXwFAr9HqdZ6UuuZFdW6P4ugI5eUuoSvZuueVRiaLus0TI64C5rwCTPmjuk0fugK0jo6nsIvG0fFhBIS9Uc3RcSd0ErKBG75hYkckYwwbByE5gNXPau/jQkcsLefwDskb3wYOL2PXj29k77eSiJyj7u9O6IjiqiJP22eIO2Gi0GhuYG4R4EfoqgrY8zW7rk8sFoUOFw1NNaqjBzBh5eu09rbm0FLgl+eAZYJAE4UOFyL+hK6ObWLHdNgBu42FowCdo6PL0QG0oUAXR6fS9+cH1D9AaPI50U0hoUN0DOmj1dBIuiB0Js9nJ8Gi3WqfEaOGge7KyzkRSb51jbaGA6NvUPMlAF3oSs5v4c5PcLjnEJ2vjg7vo9PcoDo6+p45vjDtUXa56zNg3UL1pG5UccXh86u462EyMwFybKMqdBIMhE59uTaBuVwndLijE56ghg1FocNPsCaLVkwawYVQZYGanF6eq+2Lw52FkGiho3Wta9dnXyevtzW8hF8M37XW0fnxQeYSHV2lnVwuJiPrHR1Am5CsFzb+9tLhf4A0lLv2TSKIbgAJHaJjMJmA8//JHJURV6rbw+OBs/+s3ddoBIRe6OhDIa3pMG3k6PBybv1cLz3x/dT16kdMiPB9bHWqC+XO0fFE+mnA8CtYZ+ElfwJeGcNCPPu+k9fby/UxPHQFANnTWQ8gAMhb41pxBciJriYAkrZPjt7R4SHDsHgWMgOYyODJrmLYylu/KH5iPrlDdS2a67Q5N+LwVDHfRR+u6qzwFZ9FJpbcK0InVhUizfW+JQQ7nUCJLESrj6uCwxysOjaaPjrC91gsMeeCk4vgljo6gGvINJD56vfAh5f7n7xNdDlI6BAdx8DzgEvfcv3rfszNamM7wDgZWR+6sgRpG/T5OhzVCI3QkYVNyhDg0nfYej1hCQJmvwxM+7M2r0cPd3RqT7HQkzmo5Wu++HVg9r+Y+1R1DPjtZSB3NbsvxkDohMezROa4vsBFC9WWAHm/GoeuzBZVtInuiN7R4SIoPJ6FUkxmJsB4ErHYQ8cb7sJ+YqWYL6ErwPNcr/aE9ziyNzBBC6hCJzRW67j44urUFKojQ2pL1Iqr4HD1+yT20RG/x1w4NlSoApG7lH47OkI35vIeInTsNpZ0f3gZhewCgCDvuxBEO2MJAmY9A3xwIUvaNSov1zs6ABAep4ZjWiN0xJOsGPoZcYVvjx95lfd9xHwjgDkvPPnXXyzBwJibmDu243/sr/66YiY0RrhZy/VfMofAbAayzmTbjm1UuzrrGxdGJLHBm1zoSBJQJoiOijy1h05YnCyOEuUBokUsNCj20PGGXgxFJLHnLj+qjkxxl4ysr7TqDEfH0awtv64vY99Zpeosjn2fzUHMsWqq9S4AxePVFqmhK2u4KvzFHB2rQY4OD5MCTIgfW++/o9MsOjo95KQvCtHSQ6zxKdFtIaFDdA36nglc8QETBBa5CZ/Fg6MDsJNHRR677m0UhSf4X8JhcdoJ6W2J/rjuSsv9PebYW3zfn+cwxWUB0RksHAIw0SUmsgLMoSmB6s7UnJJPtHJIq65YLZPn7k9Uiix0ZOHhaw8dQJvfFJnK3L8t73twdOTPzGlneT0ieoenIyg7wrp/c+rLWA6WmKNjMjEx0lipOj4ejymIirpiwdEJE4SO6OgY5Ojwzyg4Qs298tfRsfdAoSMOi6Vqs24Pha6IrsPQi9kJjuMpGRnQJiS3KnQlnxSivOTjtAbRnQJYs8bOwmRiwpIjhq04+sorHrKI66MKl8Kt7JI3r+OfQe0pdtnS0NXAWarD5E7oiO4F34d/jq3ppXNqN+sz5G/Sbck+7W2epyM6OoAq0HyZdyXmw9QWqyGk4Ahtcjt/X6wGOTpcBIbGqJ+b346OELrqKUJH7+gQ3RoSOkTXRTO93JvQaUUycuZ4FrIaenHLj+GNIL2j04JE5LYkSxQ6A1zvV4SO7Ojwk258tlp6z5NveVk/T0jmoSN/QlfWSHXI7KALWD4RAFTkqvvwMGVIFHOn+PwzLnR40nVrQlc/P8X6DO3+Ut12Ygvw7nms1NsdxboZZFwoiY4OoH6PjUrM933H2izwSrMyMXQlCB1N6MpgqCegCireyiAsVv0c/M7R0SUjt3RCfM0pYPVzrk0luyLi50OOTreHhA7RdfEauhL65ngbLuqJ2N7AA/uAKY+0/BjeCAqBZip5pwudM9TrHoWOztFJyFaTrnl1FA9dcbHJT2SKoxPrfT0mEzDxLmDwHKDvFFbNBrC8IH5i5Sd07hDxEzsvref9glqajCxJ6iw2sXJq15dAwTrWyNAdRo6OvUnNq1GEjocS8+/uA5Y/ARSsZ7c1oasSXeiKC2dJXatReXmN3F+pNY4OT4gGmLDi77cnmmqA3F9ZXhhn3UJg5VPApnc8P7auDHjnHGCDl0KA9kR03EoPtVzcEV0CEjpE18VsVodr6jsjA20XugK8lz+3FpNJ61C1RY5Oa4jro4oJsfycox8DYeTocFxCV9zRkR0YXxwdADj3KeCq/7KQJX+OpirVFdGXUeur91K50GmhY1BdqOb3aCZ+y8/vqbSaOzrciaorVY9hMqvCQ6kW0wmd5kZVsOStYSJJzD1qqlar3IIjtMJfKbsXk5FlMSjJQiM0tm0cHcC38NXSx1hxwb5v1G3ceePNLd1x4AfW0PK3lz3v53QA718I/PeSthci4ufTVNV5vZmINoGEDtG14eJAP+sKaLvQVUcR3IWEDgBc8T4rN+cDQ0VcHB35JJVgIHS4sxYlh654nyBfxz8YYQ1Xc6b4cxvOdBJIGa5ds7/w+V+A1vXg192d4O021fHiA2Try4TS8hg1EVxxdHQ5OmICdd4vLMlecrK8G+5s8sR7azirVLToGlmKOTr65pVtkaPDP3cu+EoOqr199PCw5qnd6jb+vagvdd3f6LFVxzy7cyX7WYuEIz/7P9bCG3rHjcJX3RoSOkTXZtytbOyBvvwZUJ0Ei7VlJ9OORszT6ezQFcAGq552vbGbJQodp9Oz0OGfQ0I2u+RWvz+hKyPiZXfEndARHR1LiPr8TdVqmMcfNEJHGJvAX0ddsfFAzLLDLIwXEg2kjmDbRKEjCnIlGVlXdSUmUB/byDqFA+w1cRHPhQ4PW+kr+YxGQHA0OTp+DvXkVVc8NFh2GNj6X2DhOGDxH4wfwxPSxfL2Ki50ylz3FykWwoAnt7vf78RW9XpbOy56x42ETreGhA7RtTnnr8B1nxn3nOEnkMiU9g89tQW88io8wTgU15XgVWEVucC2/7KTnTkIiOmtEzomVcjEZ7PbjZXsZOZPMrIRitCRE5I9CZ3IFCZ2ufvRkhJzUeiI4R3RATFydXh+TtJANeRXX24sdNzNuxLDbfZGYMen7HpijoHQkROaxfCVOVhb2efJ0Wmq8r3brySpQidVdszyf2NduQHXeWT8MTxPi5e325vUz0Q/lV5PiZDYLX4megoFodPWU+v1jhtVXnVrSOgQ3Zf00SwJeeCszl6Jb/C/wLuCm+ON6HRg7K3s+vf3s8u4LBYyiclkeSeALC6EPCoekis95F8fHSN4DhF3dMRZV4A2dBWZxMSukifk51/4kqR1D4wcHcA4T4fn5yQNUhOz3Tk6vOpKHxrR5xXx4asJ/dVEezF0BWiFjr4Pkt7REXN0AGNnygixhw53dAq3qnlBRgKjqVpNYOZVXzxsBXh2dBoqtMnOomujp10dHV3JPjk63RoSOkT3JTIJePAAcP5znb0S3+D5Rl0hP8cXZv6d5b3w7snxcmjIEswaDgJq2IqTKIcYyw7510fHCFHoOJ3qX9mKoyOc3LkYMBou6gtVx7QnYKMcHcDY0Sneyy6TB2uFjuJoiaErYXSFCBcMPLzJk4gT+quviYsOJXQlCB0xPwdwTdQOjWGfG3eDfM3TEXNweLI3AKWCsLbYNRFYLB+vPsEGw1YJQqepmuU1GaGU6cvHd+fo2JvUIapA+4Wu0kexS3J0ujUkdIjujS8Ty7sKiqPTTYROcChLWObOCc+BAdQSc/0gUz4FvXifa2m1v8QJOTqiA2Lo6OiEji+hK0lSXRd+QuXuExdpdpu2YZ54wju5A/jftcD+79ltvdBRhp6Kjo4wjFSECzOxYSagFTocJXQl5OjoHR2j0BXgf+WVMkhUDltycXXGfHbpbHZNBOb5OQATyTUntY4O4N7V4WHAPpOZa1h7Cqg2KGc/tVvbibrNQ1dc6JzGLisL3CdeE12ebnSWIIhuDnd0OrMrsr8k9gcu+zeQMQ4YeY26nefphOkdHVnoHBea67XY0ZGFTn2pWpIs5qJoxkboHR0vJ77GKuDf5wL/HADs/1EVOnzgaXMdm1+ldz64o5P7K/DWVFYKDRN7b/qcoQodyQFU5LPrho6OXujI6+0zWdsqISHbtUeUEroShI6+As1s0W7jAsffyivFRQpnf1Sc9zQw4U5g6p/Uz1XvpugbAlYd0yYlA+4rr3gicq/TgKTB7LqRq8P7HXG8OTqF24H1b2j7+niCfz5xWfJ7JmnDljVFwGuTgPWvGz9ekrznIhEdBgkdgugoBs5i3YOzp3f2Svxj4HnA3OVA2gh1G28yGJ2m3ZdXx53cwS5Dols+vDQ0hg0KBVjHYICFZHjiuehicHEQ4UPoqrEK+O+lrFeLwwZ8dTsTOwDQb4p2P73zwTsDb/0PCy/1PQuYtxG45A3W/ycoRHVtuCgySkZ25+hEparNHCNT2et1cXRkoSN2C9c7OoBWCLbY0ZHdLC7Sx9wEzPoHe63u3mvR0QGYyPHV0eFCJ3mI6qYUGuTp8G38c/cmdH54APjpD0D+Gs/7ccQwKf+ui3k6Bb8BxXuAbR8ZP37tS8Bz2cCieS2rACTaFBI6BNFRjL8NeHA/kDyos1fSekbfAEz/C3DGA9rt/KTgkHMwWlv2P0p2kXZ+wi7F3BPRseDl8N4cneYG4MPLgBObmQDpNYad1EoPsPt7jVUFQmOV6nxEpbMRFc11zKE4tIRtn/onIEnXWZrnLXEHQEzGDvEidCJTgH5T2fXkwdrXxAn2wdEBtAnJfA3+Ojq8WaDYA4qjJH7r3usandCpLHB1dNy5HSVCYjfPjzF0dGShk3Ou8Rr0cHdNPwDWHeJEeP6dFvOzeHsAd84UX9/2D4F3prOeQ0SnQUKHIDqS7lAG7wthscCZD6q5OpzodDWHBGh5xRXnnCeBi99QjyMmP4cY5ei4Oflydn/JwmqhscAN3wDXfqbmTFmszEng4qyhUq1OikhUX+u2D9n2sHg2J00PD19xV8BbebkkqeuNTAZGXste93n/0L4m5RgGQkeffAy0jaPDq6eMRrBE6ppKcrjQ4c5W1TE1GZmvycjRqSuVj2Vipfrpo9n2wm3ahOemGtVdGTDTeA0ijmZVkPgyvgIQJsJHqblpYuiKC526EuOuzLwqDSaWrP7hZb6X9GuOUwsUbPA95EYY0mOFzsKFCzFkyBCMGzeus5dCEIGDyaRNWm5pDx3xeKOuYeGhyfexvkocfR8dwHsycv46djnuVtYwMSIRuPojJk4Gz2EhGdH1UKaPx6phuY1vs8sB5xmH5fQJ2t5CV03Vai5MRDIr1598r+r8cbeKozg6YtWVB0fHZFbfKyXZ2sdOwtzRCfLk6OhDV/LtjDHssvIYUC07OmJDRYC9v8seB07uVMNWcX1YWC51GMvJqi9T+/EALN8GEqv84+NLPAkdUfT6OlCUC9GQSFVciyX5XOg47cbuGN939r8AmICqgpbl7Cx5FHj3XNVBJFpEjxU68+bNw969e7Fpk4eJxARB+A9PSAbarmN1VAoTOTxZGNCWVOtDV9WFwLf3svwbcQxBgSx0Mk9Xt6WNZG0KLv+3ds2NlcIYi1i1oozPnHLXv8mT0DFKRuYn4pBo40aSIVHartpGQsdTjk5ojOokcuGpPzkfXMLcrop8rUPBc3T0XZgB9T3X9yzijk6G/EdkyX71xJ82kl3yk/72j1k+ywcXAnu+Ytt4EnJQCJAyhF0v2KAen+fn9DpNXUNzvfFEeHE9gP+OjjXKWJyKna2NBAx/vYkDhPfplOt+3ji1i12K3aIJv+mxQqe9qbfZsfYwZd0TPZAEUejEtt/zcJciKEy9HpnCSqEdNjZtfOenbCI4wARF+REAJiBT5+RagtXrYnhH4+gITpXFCmSfbbwuj46OvE57A+svAwj5OW7mtZlMapgIUJOQvTk6ehdHvC6Grg78BHx8JfDFLcC/RgAvDlOTye2eHB13ycjy7V5j2SVPRA6JUcN/PJRUJpfrN1YBm99l13luEgD0n8Eu9y5Stx1eoR7fGqmKQHeujigwfOmvJElC6CpSEDqCuBGvG4VJlWaZMUykA767SSI85NfW5fM9DBI67UBRdSPOenYlbn5vE05WUe8FoochOjqtDV15ImkgMHg2C2lxx8IaAVzyJjD+dmDSvWxb7mrWVblgPbudPMRzbx/F0anSOTrCvLW+U4xdFACI0AudWPW6+Bh+MhUTkd0h3mc068ooRydUcHT0a+GhI1s9sPhhdj0mk4nE6uPAgcVsW7OnHB1e8SSchG31an5KrzHa/WN6qSKwTn5+Pt5DHFAqCp1hl7HLQ0vZ51FZAOT+wrYNvUQrAt0JHY2j44Or0lyvNmy0Rhp3sxav659XkrRCJ1Ieduuvo9PcqL63LXGDCAUSOu1AclQI+iVFwuZw4vVVagLbyv3FeOr7vWh2UGIZEcAkdpCjY7YAV30ITHtUu3345axb9rlPMnfJYWMnymNy+KP3BM/H9ZajA3geOyI6OtYorVsUFMLyTgDVFRATkd0h9tLxteoqRJeADKivIX8tsPZlYM0LTDxEZwB3rQcmzmP3887NitAxcHSUkIwgdPgJOSiM5T+JAi26lzALTBY6FbLQufh1VWiJCd7JQ1gFlsMG7P8B2P4/ABILYXJ3yGgdIqKLU3PKOHlYRAmBmZjICfHi6OiFTnM9y90BWufoiCX55Oi0ChI67YDJZML8GezH/pONx1BY2YCDRTW448MteGdNLpbtbYGFSRDdBVEQtKej4wuDL2SX+79X83N6T/T8GCWPRefoRKezk3FwODDwfPePF4WO0evXOwQ+OTqC0DEKXRm5S/wEyx0FAOg1GpgiTxxf9hjw6/Ps+qx/sGNwZ4i7MrzqKsggR0fsYcOrgvjJPEoetCt2ARcdnfpSVg3FZ2H1mQTctQ64e5N2aKzJpLo6uz5n5doAcNrv1H24CHTr6Ah5Oc5mNnDVE0p+TiR7fqNKOU85OtzNMVnYZ9VSR0csyfd3pImv8PBpgENCp52YlJ2ICX3jYXM48a/lhzD/k+1osrMfg10nfByoRxDdEWsE++sdaLtk5JYyaDa7PLRMzTvpfbr7/QFtebk4r8tkAm7+Ebh9tWujRBFvQkcRE1zo+ODo8PvMQapDZPWSozP0UuDcvwFT/6jdPu1PwLT/Y9clJ+tFM0gWhDyBWXF0PPTR4U6KWHnET+b85C52AY/OUBtA1pczJ0lysPwf3hyRzzcT4ULnyM/sMSHR6noBH0JXXhoa6uEij4tHMRmZu0GeHB0+fJZ/Z6Lk98KXsJmIRuj44egc2whs/a/3/Ta+DTydAax5ybvL1c0hodOOzJ/BGk19uvkY9p6sVrbvJqFDBDp9z2J/0aYO79x1pJ/Gmv3ZatkJOSrd+6wxMXSlDOaUt8X2dm0QqEcjdAxygZQTpywm/HF0xB5FGkfHqI9OJDDpbnWUhsiUR4ALnmcl8he8IHSblo/TqHN0jKqugqzq6+OvQXF05JO7xtHJ0I7I4I0A47I8z6xLyAbSRqm3h12mFXlKh2Z3oSudwPBWeSU2CwRUB01ysGGigOccHSU/RxaN7srwvSEKnaZq3zssf3Ub8O3dasWWO/Z9yz7f5Y8D389nDluAQkKnHZmYnYDT+6kNzuZNY1Ubu09UQQpwBU30cC5aCDx0SJtY2hmYzcCgC9TbvU/33rRRTEZWHB0/BpN6Ezr6EnNfhA4/mYsneG85Ot4YNxe49lOt6+Li6HgIXYnrqtUlzXKhE9tb3TemFxNHPHeIz6uKMxBierirAwCnXa9bg4+ODv9cvOXKiBVXgHbUBr9PHPTqLnTFv0ctdXSqj2tv+yKU7Da1C7S3ieslB9TrW95nAilAIaHTzvxx1mCEWy24eXIW7jk7B0FmEyrqm1FY1djZSyOI9sNsca0+6iwGC2EOb/k5gLa8XO/o+EJYHACTcF2Hvi+LL6Er7spEGiQlA8aOTktQwmo+hK7E9fDXUKMTbaKjw8OZvAEfH/wq5uS4Y/gV7L3sPcm1mstT6MrpUCuXuCvkr6NjtqjvNf/MPIaudEJHdHQ8/YH76/PAG2eqOUT6sRm+hK+qTwCQn6My3/1+9eWqcLpUboC552vVyQswSOi0M6MyY7FnwUw8PnsoQoMtyElhPyQUviKIDqLPZPWvfj4w0xP8BFVfrp7Y/KkeM1tUgePJ0bHVyidi+UTpydFJHQ5c8T4rned4S0ZuCXqh42kEBODaidrF0TEQOrzyiudMGYXW9ESnAfN3AzcscnXkPIWu6krkUnGTGkb15oyIAz053NXhIshj6KqSXeodHYfNc0fqbR8Bp3ay5o2AKnRMZt/WDWg7SHua68VHaMRkAiOuVNfqa0PFbgYJnQ7AJPzHHJbOrOE9JHQIomOwBAO/+xq49nO1064nuKhpEv6P+ptUzcMknhydplpWZs1PxDxR1x1DL9GGAlsbujJCCV3Jf9l7GgEBuE4w5+EZLtoSBwAZ41noibtC/HXywa++hK4AJuaCQgzW4MHRUdaTzHKEAP8dHfG6rU5uKCg4Oo2VLGSk3NY5OkEh6vfAU/iKN1Hks7240OGdon0ROpU+Ch1leOpAdslFqH7KvJ7N7wKf3aCGNLsJJHQ6mOEZ7MsvVl5Rvg5BtDOpw4EB5/q2rz5MZY1i86f8gQsdIydIDF3xk1dEov/PEZ3OTlC9xhjP3GoJoUKOjtPpeQQEIISuZJFRo3N0LMHA3GXA5e+qj9F3jvbF0fEEX4NecADa/KdIH/vZiAM9OeJn5rCpfXI44pBSLhLFz95bibmjWRVIhduY88Pf+16naV+LJ0RHp8JD6Irn5yTJ89Si09lldaGHxxwEfngI2PuN2p26m0BCp4MZms6Ezu5C9p/h1Z8PYdjjSyiURRBdhaBQbafelvQCGn45cyrE2VwcMRnZl0RkdwSFAPdsBW5Z6v9j3aGc3CWguc7zCAhAG7qy29Q5YGLvHj2a3C2TNmG5JYTGsrJ7wP0k9ahUICpNu80dTbpkZPG6rVbr5iidnoXn1Ts6gPemgWJvn1M71UaKEUlArNwY0V+hU3XMfU6Qi6Pjg9BZ9hirPAOAssPe19KFIKHTwQxOi4LZBJTUNGHt4VK8uPwQ6mwO/HqI5mIRRJfAZDKeD+UP428D7ttu7FaI5eW+JCJ7IjjUfyfIE0GhqmhorPY8AgLQJtryE7E5WE04NkIM0cVkGIej/MFsVo+pFzqikORio9ZLd2Seo2M1yNGx1amOT1CoKp6MhA4PAwLeHR3REbI3Aod/ZtdjMlwTvj0hhq7sje7FkYuj4yV0dWQlcPAn9Xb5EeP9jCjay4a3diIkdDqYcGsQspPYD919n2yDw8n+wxXXUBUWQXQZjOZDtRViw0AeXmiJo9MemEzahGRPIyAA7QTz4r3semSK5xL+CEHo+FJx5QvuKq94Pk5Uqvoee0sKNnJ0xGRk3s/GGqG+FrHEvEWOTpn29r5v2WVMhhBy86E8XXR0AOM8ncZqVdAkyj2hPDk6TgewRG4wyd2lMi9Cx+kEdn8FvHc+8PpE4Lv7XKfcdyAkdDqB4b3Yf4DSWjWeXFzd1FnLIQhCjyhu2rq7s5jvsf97dt1bt+aOROyl42kEBKAdA/GTPHPM0xwwQJuj09r8HI67yiuxgWFQCBAmO02eRIPNKBk5Sr2Ph66sEcaJ0EZCx6ujo3P0T+1klzGZvjs6TqeawMzL+o2EDq+4ikpTv+dc6FQZODoHfgSK9zBn88IX2TZvoau1LwJf3MxmqpkswICZ2kq1DoaETicwtJf6H6B/MvvPRI4OQXQh2tPR4e7AyZ1A0W4WKho8p22fozWIlVdKHx13DQNlR0NysHBGVBow/THPxxdDV75WXHlDyRXSh650IymUPB0PlVeeHB0xdBXsh9Dx1dHhA1850b3UtdcVqzPFjKgrZm6VyawK54o81/30+Tn8eQDj0FXxPnY56EIgYyy7XlvkuefOMblH0vArgPm72PDdthK1LYCETicwLouVGiZHheD/LmClg8U15OgQRJehtTk6nuAnUN57Jnu655yWjkYc7Gn3InQswVqH5sIXvTtgEe3h6Mjiac/XQOF2dbt+JEWUkFPkDqMcHaNkZH9CV94cnTpZ6PTRNbSMydDOFPMUcuNuTlQaEM+68Bs6Oly48PwcQBU6jZXaZGtAbTwY14e9Jr6e8qPu18JzeEZdxzpidzIkdDqBERmxeO/mcfj8jonol8j+UiiqbjQsMy+qbsSxch9nnBAE0TaIJ6m2FjriCRRgFVpdCU2Ojvzb467qClDDV8Mu8x62ArTCqK0cnX5TWYjk5HbgrSnAF7cyN0pxdOQ1ttrR8SV0JQz15ChjILw4Or3Gah8XkynPFJOFsKeBpFzUxGSqlWxGQkdJRBYcndBo9XtZrXtveIIzD4cl9GeX7sJXDjtQnqvdt5MhodNJTBuYjD4JEUiOYj8gjc1O1DRpezM4nRIufe03nPfSLzhFIyMIouMQw1VtnowsnECDwoCB57ft8VsL76XTUKH2i3Hn6ADAmQ8ykTPrOd+Ob41kjkNYPJCY07q1cvrPAO7eBAy/EoAJ2P0Fm93E18+FjthLp7nRuNcM7wpt1DCwqVabw6MXOs2NgEN2542ETnOdenwRLnQiEtkgWg5vcsgfX1vEkqF3fuY65JMnIsdmMvcFMB4Doa+44igJybrwFRdLXDwlyG6Ru4TkqgLA2czEcXTnuzkACZ1OJ8xqQVQoK+csrtaKmVPVjThR2YA6mwMfbfDQ/IkgiLalPUNX4gl0wMy2G9/QVnBHR0x+9SR0hl/OGgL6OtvMZAJ+vxq4Z4t2YGZrScgGLnsbuPYzACa1ciksnrkigCoYjq4EXhkN/GsEcGi59jj6oZ6AtjOyoaMjh6542Mpk1gmlCNUxMXJ1eDJyeIIqdCxW9fhiQvLiR5iI2/C69hiK85IhODrHtHk9TbVMiAAehI5QeSUmOCtCx4ujwwVQfLbnqfQdSNdYRQ8nJZq5OvrKq6Mlaqz04w0FaGx2dOi6CKLH0hHl5UDXC1sBxkLHU+iqpc/RXnlJA84Fzv6zepuHqwBV6JQeVJ2LPV+r9zvsal6S2z46Rjk6xaw3j9JDJ8r1JK8kJBuEzbijEy44OtG91GNwJ6p4H7Drc3a9cJv2GFVCiCkqnYXynM3a5yuV3ZyIJNf33yghufYUO4bJor6PPP/HrdCRt3PnpwtAQqcLkBzFGmYV6SqvckvVcryyOht+2BmYA9cIosuhKS+PdbdXywiNARIHAgk5QP9z2vbYbQGvuuIJu0GhnvvidEXOfJBVCQHazsvJQ9mlNYpVBAFA7mq1gaBNCCsZdkauYeEnQOvo2BuZE2SUiMyJFMJPenhn5PB4IGcmMOJqYNr/CY+VHZ3N76lCrOSg9hii82IJUsNeYp7OqV3sMmWY6xqMHB0l76eX2piSOzrlR4wbLypCp2vk5wBAG7bUJFqKW0enlP2HigoNQk2jHe//lodLR/fSDAklCKIdaE9Hx2wB7lrH5hu5a8TXmXChw/NOPIWtuiomE5v0vuU9Jhw4if2Bu7cwQREUwtycqmOsDDu+r5qIbA7Wdmw2DF1FMrETHM6StutKPAsdxdHRJRRLkhr6Ck9g34lL39Tuw0WSOGi2/Aj7DlnkknR90nBsb5ajU1mgVnNxocMnuYsY5egoQkcQi/F9AZjYa60v0zaABLqk0CFHpwugODo6oZMrC507pmTDGmTGrhNV2JTnobyQIIi2oT1zdAAmdrqiyAGE0BV3dLqh0AGYCzPpHiBpgHZ7Yn8mdKwRQMY4ti33F3ZpNNAT0CUjc6Ejj8UQS8wbK9l1o+8MFysnd2i32+rUBGa9aFAeK3TODolm4sopVDc1VqkiKJYLHYOEZC500ka6PodR6EqfiAww4cvFlFH4iufoUOiKEEnmjo5L6Ir9hxrTJw4XjWRq+5q31+Pm9zZi2V4fBrwRBNEy2tPR6erwkzzPG+mqgqwt4ENXudAxKi0HjBsG8m3KGIwiYXK5gaPTfzq73PUZsOEtdTtPRA4K9TBTTJiFNupadXQDz7nhbk5YvLoufeWV0wGc2s2ue3R0DEJX+sGrCW7ydJob1FwhcnQIEe7oiKErm92p9M/plxiBB84dgNG9Y+FwSlh5oAS3/WczDhUZlCkSBNF6YjJZT5OBF6ihgZ5CaLT2dnd1dHxBFDqSZNwsEFAdHbE8nG9LkEvki/Z4Dl31nw6cLXeNXvwIsFeuChMTkd2lJfAkagAYe6vaA4eXilcJFVccLk64w1Key9YfFGYsQrjQqS9TO2KLJesi7krMeRPB0Bhtv6ROhoROFyDFwNEpKK+HUwIirBYkRYUgLSYMX901GSsenIKsBKb6ueNDEEQbYwkC5i4Hruncqcudgj5s0x1zdHwlYxxzUuqK2WgEd46OeJsPp+TOSa/R7PLEVs9CB2BJ0mNvASABX93OkpDFRGR3JA4Axs0Fpv2ZheIUR0dOSOajHkTnhYfljm9i6+Lzs1KGsNCpnrA4VdTWyK6OW0fHTYm5mJ/ThXJJSeh0AcQcHd4dmYuYvkkRmuTj7KRIDEiJkvenJoIE0W50oR/qDiVE5+gEstAJClHnQuX+YjzQE5Arz+TTJc9d4kInXRY6hVuBhkp2Xf8eckwm4Px/AvH92MDU45u1icjuMJmAC54HpjzMbusdnaOr5bUIzQYTsll1n9MOHF7uORGZP4cYvnI6XROclWP7IHS6ECR0ugDJ0UzoNDQ7UCt3R+al5X0TXZuJpcYwB0ifvEwQBNFq9I5OW/fQ6WqI4St3jo7JpIazeKiJi6HU4Wwwa10JULyXbfM078tsAXqNYddP7dR2RfaVRFnolB5ieTG5stAZMFO7Hx/JcWCx6ui4EzqAOpequpC9HkcTE3j6Dse8o3XZEZb7w1ESkUnoEDrCrUGICmGV/ly8KI5OomvnUB7qOkWODkEQbU1PcnQAoO8UdnlgMbD53+y6PkcHELo4S9rbwaFA8hB2/fhmdultsGnqCHZ5aqe2K7KvxPdl4qq5Dtj5KStvj0p37Y/Dx4scWqpWe6UaVFxxxMorHraKSlc7S3NiMpkAdjRpq7q6YLNAgIROl4G7OjxPh3dF7udB6FDoiiCINicohPWR4QS60Ok1hk3ZlhwsTwcwHsuhH1chVkjxPB1Jdje8Ch3ZVTkpODr+CB1LMAt/AcC6hewy5xzXcGvGWJbk3Fgl90UysRwdd/AQVf46VcDoE5EB5kpx16b0kLqdHB3CE3y4Z0mNL44Oz+khoUMQRBtjMmnDV4EeujKZgItfA677Qu09E5flup9Lyblwm+fpcLwJHd7HpiJX7YXjb5WSPiE551zXfcwWYMB56u2E/p7ni424koWqDi0B9i5i2/SJyMrz52ifv6FCdafiydEhDBDFS22THcWy4Omb5PqlTOWhK5poThBEeyAKnUB3dDg55wDzNgA3/wSMu831fn2CsigYxCRgwLvQCY8HouVS8GMb5W1+Ch2ekAwwB67fVOP9eJ4O4Dk/B2DiZcTV7Pq+79ilPhFZ2VeXEM2TnWMyu9ygWhI6XYRkYQxEnuzmJEaGIDrUtYdHipyMXN1oR4ONBn0SBNHGiL10eorQAdhr7TNRneskohE6Ju37kjxY63x5EzoAkCbn6fCuyH47OoLQyZrsXlxkTwMs8jgLb0IHAKY8wvJ/OF4dHTl0dXwTu8wY6/05OhgSOl0EdbBnE46UsMx/o/wcAIgKCUJYMOuDYBS+2pJfgYKy+nZaKUEQAY+YkBzIDQP9QXRwrJHafBhLsJpgDLg2XTRCLzr8qboCtKMtcma6388awQaYmixA/xnejxvfFzjtevW2W6GjC50d38Iue5HQIdzAHZ38sjp8s501azLKzwEAk8mklJjrK6+W7y3CZa//hpvf39iOqyUIIqDRhK4CPEfHVzRCx+C3uZeQp+Ouj46IKIyAluXocOfFKD9H5MIXgYcOqi6SN856GLBYAZjcV1Al9Gf3N5SzXkCKozPOt+foQGh6eReBOzo7j7POmiYTcP6INI/755bWaRyd8job/vgVi5MeKalDbZMdkSH0ERME4SeaZGRydABo3xMjocMTkkOijTsP69GLjjAPnZGNsEYAl77F+ugkeqlyCrICQX44RjEZwO++ZgLGnaNjDWcVWZUFrCFhXTHLFfJVTHUgdBbsIvAEYwDoHR+O568ciXFZ7r/4atNAJnQkScKfF+1Caa3aRPBoSS1GZMS2z4IJgghcQnpojo4nvDk6WWewXBgxSdgTMZlsynljJbs0ygvyxrDL/H+Mr2Sd4X2fxAFM6Gz/iN1OHdYlvy8kdLoIfRLCcdOkLIQEm3Hv2TmI8OLEqL10mLD5dkchftx1CkFmE1KiQ3GisgFHSOgQBNESemLVlTfEZGQjoRPTC7hnM5sZ5QsmE8vTyfu1Sw3A9IvEAczNyf2V3e6CYSuAhE6XwWQy4Yk5Q33eX98d+Z1fWS+Gu8/uj+KaJny8oQBHimnoJ0EQLaAn9dHxFW+ODuA+zOOOtJFM6PibiNxV4JVXvFt0FxU6lIzcTeF9d4qrG1HXZMfek9UAgKvGZSI7if3lwau3CIIg/EIsjyZHh+EtR6cl9JnMLhNyPO/XVUkcoL3dBUvLAXJ0ui2pgqOz/VglHE4JvWLDkBYThmy5ySAJHYIgWgSFrlzRl5e3BQNnAbcscZ1R1V0Qe/mEJwBxfTtvLR4gR6ebIubobMwtBwCMzWKxYe7o5JXWw+5wtvq5JEmCJEmtPg5BEN0ECl254kvoyl9MJqD36V2uk7DPRCSyRGqA9c/Rz9rqIpDQ6abwIaA2uxPL9xUBAMbKVVq9YsMQEmSGzeHE8YqGVj/XG6uPYsCfF2P3iapWH4sgiG4AOTquWNshdNXdMZnU8FUXzc8BSOh0W0KCLIgLZ+Mh9hSy/JxxsqNjNpvQr4V5Ot/uKMQDn23XjJb4bPMxNDsk/HKoxOfjlNQ0kTAiiO4KlZe70h6OTiBw+p1A5gRg1DWdvRK3kNDpxqQIvXeiQoMwIFn9i6MleTp2hxOPf7MbX209ge93su7MxTWNyiT1k5W+DxG99YNNmP3qGuSXUeUXQXQ7qGGgK2J4KZiEjsKwS4Fbl7Img10UEjrdGN40EADG9ImD2azGR5XKKz9KzDfnV6CivhkA8OuhUrYtr0K5/6SP09KbHU7sLayGJAH75GowgiC6ERpHh3J0AJCj040hodONSYlSf4D0XZSzk/0PXS3Zc0q5vuZwKZxOSUl0BoCTVb7l+xRWNsDuZMnLBeWBOVxUkiTkldZRkjYRmITHs1lGiQO1uSk9GW8NA4kuCwmdbkyKztER8Td0JUkSlu4pUm6X19mw92Q1NuWJQsc3RydPmJyeH6BT1D/bfAxT/7lKadRIEAGF2QLcuQ64Yw1gptMEADah3MKKQNqsvJzoEOgb3I3hTQODLSaM1I166JfI/iNW1DejvM4GAB7dh70nq3GisgGhwWac0Z916Vy8+6Qm9FReZ0Njs8PdIRTEvJxAdXS2H6sEAKVRI0EEHEFW9o9Q4U4OOTrdChI63RiehzOmTxzCrNppuWFWC3rFsiTCJ77dg9P/vgLnv7wGxTXGrswS2c05KycJ5wxJAQB88Fs+nBIbMhoazL4qp3xwdfJKVXFzLECFTqGcmF0mi0iCIHoA0ensMiq1c9dB+AUJnW7MhL7x+PeNY/HiVaMM7+8v5+l8u6MQp6obse9kNa5/Z4Pi8IgslfNzZg5NxZk5zNGpbbIDYPk/aTFMNPkSvsoTHJ3jFQ1wOAMvj6WwkuUrlQnT4gmCCHAuewe46iNhxhPRHSCh040xmUyYPjhFESF6zh+eimCLCWf0T8Szl41ASnQIDhbV4vp3NqBKrq4CgIKyeuw/VQOL2YTpg5PRNzFCcYMAYHzfOKTJ+UC+JCSLQsfulHxOYu4uSJKkCB0j0UgQRICSPBgYfGFnr4LwExI6AcxV43rj4FOz8OHcCbhyXCY+vu10JEaGYO/Jarz88yFlv1UHiwGwhoOx4VaYTCbF1WHbfXd0HE5JCVdFyOG0ggBLSK5utKNObqhYVmujyiuCIIguDAmdAMdk0vbWWTBnKADgV6HL8YajrLKKJyEDwJk5SQCAxMgQ9E2M8NnRKaxsQLNDgtVixmi5EizQEpLF98DmcCohPoIgCKLrQUKnhzExOwEAcLCoFmW1TZAkCRvkXjnj+yYo+507NAVzz+iLv10yDCaTCWmxstDx0h2Zl5NnxoehbyKrTAg0ocPDVpyyWgpfEQRBdFVI6PQw4iOsGJjCGoBtzC1HbmkdSmubYA0yY0RGjLJfsMWMP184BDOHsuoC1dHxLHR4fk5WQgR6x4cDaJ3QqapvdhEWRtQ22bG1oMLrfm1BoU7sldVRQjJBEERXhYROD+T0fqyL8obccqXz8ajMWIQGW9w+Rs3R8Sw6eA+dPoLQ8bXEfPXBEvx2uFSz7Yo3f8PZz69ChZek36e+34tLX/sNy/cWedyvLSBHhyAIovtAQqcHMqEfC1GtP1qmCJ0JfeM9PQTpstCpqG/22DSQd0XOSgxH7wQmdPJ9EDrF1Y249f1NuOWDTcrxa5vsOFhUi8ZmJw4U1Xh8/NojTCBtFDo5txd6V4t66RAEQXRdSOj0QMbLomb/qRqsPlii2eaO6LAghMmOj6fwVb4QusqMY0Knsr4ZVQ3Nbh8DAOtzy2F3SmhsdiqhLtEJ8hT+qqpvxrFy5rIcOOVZEIl8tfU4Hv9mt999fk7Ijk64XFVGJeYEQRBdFxI6PZDEyBDkyM0Ey+pssJhNGN07zuNjNAnJuvDVyv3F+Gb7CTidkpKMnJUQgYiQICRGshby3sJX64+WKdfzSplYEudkeSpR33OySrl+0Ivzw5EkCX/9fi8+WJePXSeqvD9AgL/+oelswnMpNQ0kCILospDQ6aFM6Kc6OMN6xSAiJMjrY3j4Sqy82lpQgVs+2IT7PtmOez/Zhia7E0FmE9JlUZTpY56OKHT8dXT2Fqrzpk5WNXp1jwCguKYJlXLTxKJq34aVAoDTKSljMIb1Ysnb5OgQBEF0XUjo9FBO76eWkp/uJWzFSdX10rHZnXj0y13g/fK+33kSABM3QRb21erjQ+VVcXUjjpao3ZR55VaBj0JnT6F2sOYhH1wd0fkpqfHdkSmtbUKzQ4LZBAxOY44OJSMTBEF0XUjo9FDEnBxv+TmcdF2J+Vu/HMGBohrER1ixYM5QWMysOWEfOQkZgFJ5JSYkV9TZMOOF1bj3f9sgSRLW52oTiHnIylehs1sOPfHBo/rEZUmScPfHW3HjuxthdzjZPkIujz+hJ56fkxodipToUL8fTxAEQXQsJHR6KMlRobhwRBoGp0Vr3B1PpMWqYyB2n6jCyz8fBgD85cIhuHFSFt64fgyykyJw2egM5TE8dHW4uFbZ9uXW4zhcXItvdxRi5YFiJWw1XA4FGQmd8jobahpZqCmvtA5L95yCJElosDlwpIQdm/f8OahLSC6tteH7nSex+mAJ9p1k9x0qUtfjj6PDRV5abBgSIqzK2jjHyuvRLIspAGhsduAPX+zEtzsKfX6OlvDz/iJc8tpaHC72PRmbIAiiJ0BCpwfz6rWjsfi+M33KzwHU0NVvR0ox59U1sNmdOGtAEi4alQ4AOGdIClY8OBWzR6YrjxmbxdyiTXnlOFpSC0mS8OmmY8r9zyw+gHVHmNC5alwmAOaaNNkdOF7BhA53inhl1b2fbMPt/92CH3edwv5T1XBKQGKkVRlboXd0ckvVsNiW/HKXffwROryHTnpsGBIiVaEjSRJ+O1yKM59diQXf7VH2/2b7CXy6+Rj+8s1uxU1qDz5cX4BtBZX4cuuJdnsOgiCI7ggJHcJneDJyY7MTTgk4d0gKXrhypGaelp6+iRGYPigZkgS8tzYP245V4lBxLUKDzYgODcKBohrkltbBZAIuHJGG0GAzHE4JW/Iq0OyQEGwxKdVNBeV1qGpoVqqkXlt1WMnPGZIeg0GprOPzgVM1mkGbuaWqe7OloBKSJGnyePwJPfGuyOkxoYiXHR27U0J1gx2r5FL9L7ecQL2Nzb/6afcpAKzEfmtBpc/P4y88r2m3nxVkBEEQgQ4JHcJnspMiMCk7AWfmJOLLOyfhrRvGIjEyxOvjbj2jLwDg8y3H8PYvRwEA5w9Pw7xp/ZV9hqZHIzbcij7xbD7Wr3KH5Iy4cGQlqDOzth+rVJKf9xRW4921ucrj+ydHwmRiTQ1LhQRhMdF5a34FTlQ2KNPHAaDEL6GjOjohQRZEyW5YaV2TUv3V0OzAz/uLUd3YjDVCp+fl+9qna7Pd4VQq1HadqKJp6gRBEAIkdAifCbKY8fFtp+O/t07AmD6e++6ITMxOwOC0aDQ2O7FYdjiuHJuJGydlKQnOp8sDRXk3ZT5dvXd8uGZm1ha58zEPZ3ERMzQ9GqHBFkUUiVVVR4XQ1YnKBvx6iImPSC5Samw+iwNeccZnf8XL4auyWhv2FKpuync7CrFyfzGaHZKy1vYSOierGtHsYOuvrG/G8Qrvs8EIgiB6CiR0iHbHZDJhruzqAEBWQjgm9I1HaLAFL1w1CtMGJuHGSVnKfQCw+wRzR0Shk19Wjy3y4M47p2Qj2KKGzIams0TmASmsEaJYVXVUTlbmguMTOUeIj71oaHZoHB5PnOChKzkxmyck7z5RhYp6tX/PygMl+HzzcQDA9RN6I8hswtGSOmUtbQkPW3EofEUQBKFCQofoEGaPTEdyFAtzXTE2U8nrOb1fAt67ebxSndVbdmQ4vePVmVm5pXXYLue5XDgyDReP6gWAOTO8Xw+fzM4dHbtDHSkxZQBLVt5xjB1jZGYsIuQxDr4kJDc2O5R8nl5c6MihO+5ADUqNQk5yJGx2pxK2umJsplLZtmJfsdfn8Ze8Uq3Q8bfTc1fjRGUDLn1tLRbvOtnZSyEIIgAgoUN0CNYgM164chR+d3ofxb0xIkvowQOw8nTu6ByvYLk1USFByEmOwrxp/ZEYacXskekwy27NAJ6QLAudE5UNaHZICAky48IRaZpjD0iJQpIsvnxJSF4jh7ySo0IQGx4MQHV01h9lIbUh6dGaqrNesWEYmh6N6YOTAbRP+IoPUo0OZaG47i50vt56HFsLKvH04v2Ub0QQRKshoUN0GGfkJOLJi4cpuTFG8GRkTu/4cKRGh8JqUb+qo3rHwmI2ISsxAhv/NANPXzpcuY87OvtP1sBmdyo5PH0TIzAuS9sYcUBKpJJM7Yuj84PsMJw/PE1xpHiJeYM8cX1oeoxGUJ03LBUmkwkzBqcAADbnV+Cn3aew8kBxmzUa5I7OecNYH6Hd3Twh+YDc46igvB47jnsWbaW1TUqFG0EQhBEkdIguRXpsKILMau5NZnwYzGYTMuLDlG1iIrTZrC1tz06KRFJUCBqaHdiQW6YkIvdNjEBGXJji4FiDzOiTEKHc9iZ0GpsdWLaXuTGzR6pCJj5CW3U2ND0a/ZIiMT4rHmYTlB5DmfHhGJgSBYdTwh0fbsHN723CZa//Bqefk9ON4Dk6M4emIshsQkV9s9LBuS1Yd6QMc15dg30nq73v3AaIDR+/3e6+0WJpbROmPLsSV7+1viOWRRBEN4WEDtGlCLKYlXyd+AgrokJZiIiHrwB4rPgym004eyALE63YV6z00OmbGAGTyYTRvWMBAP2TImExmxRHx5u7supACWqb7EiPCcVpmerz8+nsHD7/6u0bxmLp/WdhREasct8fZg3E2D5xGJERA6vFjPyyeuw71Trx4HBKSiPFASlRGCA7Wr4kJK/YV4R/LN7vtZHha6sOY+fxKny2+ZjLfZIkobCyAZX1LZv3dbi4Bje9t1ERUTa7U+l0DQDf7yyEw40YXHekDHU2B/YUVhsKRodTwraCCk2naoIgeh4kdIguBxc1orjhycYmEzAqM9bj48+W82FW7C9SQlf9klg11hn9EwGw8BcAnx2d73cyZ+GCEWkaF4k3DQSY+xQTxoRZTHgw+idHadc1KAVf3DkJ3959Bs7MYetYLTcZbCmFlQ2wOZywWsxIjw1Txmh4y9Npdjjx4Oc78MbqI0rJvxGNzQ5skGeRiUnPeaV1uOKN3zDs8SWY9I+fMekfP7coFPfu2jysOlCC11cdAcASzu1OCZEhQYgODUJxTRM25JYZPnZLPqvAczglVDe6Tqz/autxXPLab7jtP5vdiiWCIAIfEjpEl4MnJItCJ1OoquIujzvOzEmENciMY+UN2CyfDPsmstyfayf0wcJrR+ORmQMBwKdk5HqbXamWunBEuua+BCF0NTQtxvuLkzlLrgD7pZVCh88Fy4wPg8VswrAMLnQ8O0UbjpajUi6H/3m/+0qwDbnlsNmZI8KTngHgiy3HsSmvQinLr7c5WpQEzZ2cTXnlkCRJSSIfkBKJ84ezEOF3buaEcaEDQNMgkrNNrq5bdaAEzy054HJ/TWOzZgYbQRCBCQkdostx3rA0pMeE4gIhqfeCEWkY3isGv5/Sz+vjw61BmJTNyrn5STo7iQkdi9mEC0akITacOTH6ZOSV+4tx98db8cnGAlTW21BV34z3f8tDQ7MDvePDMSJDK2YShNAVH1XhC7zUfXNeBWqbWDLt8Yp6FJQZT2l3OCX8d12ey9BOnp/DhRx3dLwlJP+4Wy3dXnmgWHE89hRW4YWlB1Anr0kUYgXCwFJevn//jAGYPog5aPm6MndvOJ2S0u/oZFUjjlc0KPk5A1OjMEeuXvtx1ykXx6beZsdeIWdIHKzKER2oN1YfcRms+vDnO3Hui6uV+WfuKK5uxNM/7kNxTaMfr44giK4CCR2iyzExOwG/PTpdmUYOAGkxYfjunjNwyWkZHh6pMl2ucgKAuPBgRdjo0Yeunvx+L77feRJ//GoXxj61HKOeXIpnf2JuwAUj0lzmesUJxx3ay3ehk5UYgd7x4bA7Jaw7UoZTVY2Y9a9fccHLv6LC4KT9v40FeOybPbj7422a7fxk3kfuP8TnfZXX2QxP/gATTUv3qOEqNoerAk6nhHs+3oaXfz6Ml1ccAqD2B+KP412XuRMypk8cspNZWDC/3FikueNYRT3qhUaNm/LKBUcnChP6JSAlOgRVDc2Y8uxKvPPrUTTK1W3bj1VqwlFlBo4cf294mPCRL3Yozp0kSVh7uBROCfjGQ8IzAPx7bS7e/OUonvvJ1RUiCKLrQ0KHCEi4ywCobocRPJm4tNaGwsoGHC2tg9nEBIPdKUGSgH6JEbhuQm/cfqarm2QNMiM7KQJhwRaMyvR9LAYAnDWA5+kU48kf9qKm0Y6aJrthzswnmwoAAPtP1WjGW/BwUpb8GkODLUozQ33HZM6mvHKU1toQExaMC+Tw0Ip9xVi6t0ipUvtgXR52Ha/CwaJamE1qg8S80jo02R3KsXNSItURHW7cKM6+k9X463d7USWHzPRVXJvyypXXNjA1ChazCa9eOxr9EiNQUd+Mp37Yh3kfbQUAbMmr0Dy2TCfqGpsdKKxiDswLV45CdlIEGpud2Cw/7nhFA2pk12r53iKP7tdxOdl71cGSbl22TxA9FRI6RECSHhuGIXIFFE9ENoKHrmwOdQ7X8IxY/DT/LPz6yDRs/L/p+PmhqfjbJcMRF2HsCn155yQse+AsTWKyL0wZwMTYom2F+GGnGkr6dscJzX67T1QpIzEAbck1Fxxio8WsRHZdHGYqwjsOnzMkBecOZc7Xin1FeGM1Swi2mE1obHbizo+2AABGZMQqIbujpXU4WlIHp8QaFCZHhaCP/NyeHJ3aJjvmfrAZ767Nxb/lQaz7TjJRwztm/3KwVOlizfshjcuKx9L7z8Izlw1HsMWEFfuLseFomTIKhI8BKdPl6PD3JTo0CImRVoztw3oo7TpRCQCasFdhVSP2FLrPaSqU55uV1DRpHkcQRPeAhA4RsFwzoTcANR/GiNBgC6LkjsLfbmcCY7Kc35MZH47kqFCvzxMbbkVGXLjX/fRMzE5AkNmk5OjMkhv+bcgtx6kqNR/kU3k2F3efvt1RCEmS4HBKiouSJYzO4A5WrkHOjNMp4Sc5bHX+8FRMHZAMi9mEQ8W12H6sEtYgM56/YiQAKGGqs3ISFccor7QOh+SwVU5KFEwmk9LksaC83m1foKd/3Kf09ll1gCU/c0fn6nGZAFgXa0lir5OP1gBYy4GrxvXGFWPZfi8uP4itciLypGzmipXXaUNXeUL/JJPJhOG6JO29OmHDeyQZIX4Wqw60LnlcT3FNI/7wxU4cKqrxvjPhN23Rp4ro/pDQIQKW6yf0xrbHznEZ/aCH5+nwLryT5RL09iYyJEjpCZQUFYJnLh+BMX3iIElqOXuDzYFFsgD7+yXDERZsUToG55bWaUrLOVz0iKErSZKw63gV/vr9XhRVNyEqJAiT+yciJjwYY4W+RJePycBFo9Ixvq/aRfqsAUnoKxzzkFAZBahNHm12J05Vuybs/na4FB9tKFBu7zxehdLaJuyXE49Pz05QjsWOG+VyDAC4ayob5Lr+aDmqG+0It1owuT8TpaW60FVuqTakxx2pXccrIUmSIrK46+dO6NgdThQLrQdWt7HQ+XB9AT7dfAxPfLenTY9LsMG+I/+6FK+tOtzZSyE6GRI6RMBiMpkQF2F1SSDWkyS4B9Ygs8eGhG3NTZOykBQVgn9cOhzRocFKJ2VeIbR490nUNNqREReGGYNTcM4QFmr64Lc83PEhDy3FKJPZAaCfXGEmhq5ueX8TZr+6Bu//lgeAjbEICWIDTfkcLpMJuP3MfjCZTHjwnAEAWJ+gUZmximA4WlKHQ/KIBt4nKMhiRkYcE1r5ujydBpsDj3y5EwDwu9P7KMJi8a6TSphqcGo0xgrjOdwJnYy4cMXVAVg/pZRo5riV60NXpTykx9Y9MDUKwRbWNfp4RYPSqHHetP4wm1goy6ibdEltExxOCfwrtKWgAlUNrj17Wkq+LEZ/O1KGIgOR2B40Njt6RK7R2sOlqGm0t8sgXaJ7QUKH6PEkRqlCZ2yfOIQGWzrsuWcNT8Om/5uhVImdPzwNFrMJO49X4dWfD+H5pQcBAFeNzYTZbFJKrr/edgKHi2uRFhOKF68apTlm30TmjuSV1cHplFBS04SVshNxwfA0vHrtaXjy4mHK/heN6oW+iRGYe0ZfRdBM6JeAD24Zj//cMh5BFrMSDiusasDuQuZ85SSrLgyfOl9Qrg2XLdtXhOMVDUiNDsUfZg3CtEEsjPj2ryxPJzU6FHERVowXhM7AVGOhA6iuDsA+K54Xpa8wyy3jjSLZukKCLMpx1x0pU7pJT+6foOTvLDdwdU7KYav0mDD0S4qAw8mqtZbvLcLZ/1yFPy/a1eKu0IAqDCXJfb+gtiSvtA6j/roU/7dod7s/l57vdxbi7OdXKcNx2xsuHDtKQBJdFxI6RI9HdHQ6KmzljsTIEKUH0D+XHsSJygYkRYXgKjmP5awBSUr35cTIEHw0d4LSTJGTERemJBQX1TRiq5y4OzAlCguvG40LR6TDGqT+10+JDsXKh6bi/y4YojnOlAFJGCb35UmMtCIyJAiSpObuiM4LT4bO0zk6S+R8oEtG90JkSBCmyuM5FDcnTU467uvd0WGvLRx3Te2PqNAgXDgyXWnYWOYmR0fMXRreKxYAlFEW6TGhiA23YsaQZM1aRXh+TlpMKKbKyeMvLDuI2/+7GUdL6/Dh+gKc/fxqfLX1uNs1e+KYkMDNQ5TtybqjZWhsdmLpHvc5Se3Byv3FmP/JdhwtqcNfvtntdexIW8DDqMXVTT3CwSLcQ0KH6PEkCY7ORFlkdCY3T84CwNyIP18wGMvuPwvJcojGGmTGg+cOwGm9Y/HR3AmGFWXBFrNS8p1bUqcIndF9Ylu8JpPJpFRzAUBUSBBSotX3zajEvLHZgZVy1+Xz5J5Ip2XGIjpUnV4/SA5l9YplobnhvWK8Nl68/5wB2Pn4uRiQEqU0bCyvsymJp3VNdiWvJitRFDpMtPFu2Xwu2XlD02AysfCRvlNyoRzOSo0JxdSBzI06XFwLp8TcsZzkSJTX2fDAZzuwrUBb8s5xlxBb22RXyuItZhN2n6h2aQjZ1hyV54iV1ja1aGSHEZvzyvHKikNux2xsya/AnR9tgV2+/2hpHb7a1v6ijotUm8OJinrfwo2nqhrx0vKD1BwywCChQ/R4uKMTFRKEEb18H+PQXpw9KAV7FszEigemYO6Z/VyaHd4wMQtf3zXZY4iHOyy5ZXXYll8JABjdu3W5RzwkBrD+OWLuE29YmC+ErtYcKkW9zYG0mFAlGTjIYsaZOWoVHBcbAPDOjWPx3T1n+BQ65M/NGzY6JaBSzp3hSdjxEVbF/QLg0tWaP3fvhHDMkEOH/16Tq9mHnyzTY8Mwvm+8UqF3z9n98eq1p+HH+87EDDnHSWwRwKmos2HyMz/jlvc3udzH3Zy48GBMlSsDF21rWfiqye7AT7tPocnu8LifmLd1QJgSv/pgCVbuL26R0/LnRbvx/LKD+HGX6+uvt9lx2382o7HZiakDk/CwPHrlX8sPeV1raxFDVuJ1m93p1uF585cjeGn5IXwg57J1JWx2J81sayEkdIgez7i+8bBazLhsTAaCLF3jv0RESJDXJGpPcFFyqKgWO45XAgBGtzLJuq/QqydHN7BU6aVTVq+cRHgoaObQVM1r4c4IAAz2INZ8wRpkVhwiXmKeW+raWwhgITGr8PkOEZyj2+RmkF9tPa5xOniOTmp0KEKDLfjfbafjw1sn4MFzB8JkMiHYYsblY1i37iV7T7mcQJftLcLJqkasPFCMeptdcx8P3/WOD8dFp/UCAHyz40SLwiwLfz6MOz7cgld/9lxhdFRoOcCr3g4V1eDGdzfi5vc3YeI/fsYzP+1XOlB7o8nuUNoN/HbEdfjq7hPVKK+zISkqBK9dNxq3ntEXyVEhOFHZoLRNaA8kSdJUAIr5OmOfWoaHPt9p+DjesNKoNUNnUtPYjKnPrcQ1b6/v7KV0S7rGrzpBdCJ9EyOwe8FMPHbhEO87dxP6ykm4i3efRJPdidjwYPTz0CHaF8QwUE6KNmTGQ1c1jXZU1DfD7nBi+T6WB8KbEnKmDExCaLAZCRFWj12rfYU3feSDPZX8HN2xrUFmDEpThZXoJo3LisPIjBg02Z3477p8ZftJuVlgWgwLHQ7rFYMzcrR5XGcNSEKIPER2/ylt6Im/B5IEHCzShsUKlIGs4ThncAoirBYcK29o0XDUn+XeREZ5Rhyb3amIKwA4IFeerT2sJgeX1DTh9VVH8MxP+3163sPFtYrLsO6Ia5IxL+MfmRGDcGsQQoMtuOfs/gCAl1ccRnE7JQpXN9jR2Ky6U1zobMmvQHWjHUsNRCkAHClm3x2erN5V2JhbjsKqRmzMLXc72oVwDwkdggA7CYol2t0d3vemqJq5E6dlxrbKIQK0ozRydAnDocEWpMp5RPllddiYV46K+mbEhQdrKqoAIDkqFF/fNRmf3TGxTRw0feUV76FjJOx4nk641YI+QhK3yWTCXNnV+e/6fMXRUJKRhT5FesKtQUo4ThQajc0O/CpUGHFhweGio09COMKsFkySE+HFx+SV1uH7nYUeG99V1TcrnZ0PFtUqeUV6CsrrNaEPLso2yTlL907Pwd8uYdV4H28o8ClPRQx/5ZXVK8KQwxsziqLyqnG90S8pAqW1Tbjh3Y3KSBCR3w6XtipPRt/Pif8/4FVuNY12ZRuntsmuPK7Az7lt7c0mYeTJft33iPAOCR2CCEC4o8Npi95AGqGT7JoE3VsOFRWU1+PrrSzZdMbgFEMxMzgtGtkeRnP4A09I5oM9lbEYBkJnZGYsANYo0KwTtrOGpaJXbBjK62z4fudJOJwSiuSkZu7ouGOm7FqJ1UzrjpShQQgB6d0eMXQFsA7UgDpIVZIk3PHhFtz98Ta8Lo/nMGJjXjlEc8Jd92aeiBwbzvKWDhbVwOGUsCmXTW+flJ2Aa8f3xqjMWDTZnXjn11zD44joX9M6XfiK9ysaIggda5AZ7980HklRIdh/qga3fLAJDcJw1w1Hy3DtOxsw/5PtXp/fHa5ChwsYNSR1SJf4nSvkL1U1NKO6se36JbWWLfnlyvUDp6iLtr+Q0CGIACQtOhQhQgl5axORATbqYv6MHNw5NVvTiZnDHZJnfzqAz7ewcuvZct+f9iReKTHXha4SXIXOxaN6Yf6MHDwxZ6jLfUEWMy4bzXJlfjlYgpIa1iwwyGxSwmPumD44RWk8yJOMediKCwv9CYrvx9sDnCG7QlvyK1DXZMeBohpFSLy47CB2uwlpcXHBP28+YgMAjlfUo1lOMD5Swqe5s9BhY7MTvx4qQXFNE4ItJoySXb/7pucAAP67Lt9wKrwIXx8fTyIKHbvDqdwvOjoAE8X/uWU8okODsCW/Ai8sUyfD8zlmG3LLUWMgNuqa7Ph5f5HHxNyiKndCR3VqDulCiUdLtbePdRFXp8nuULq2A8D+kyR0/CUghM7333+PgQMHIicnB++8805nL4cgOh2z2aSc6M0m1cloLfNnDMAfzhtkeB93UE5UNsBkAv44axDO8jBnrK1IEEJXJTVNKKuzwWQydnSsQWbMnzFA6Q+kh4ePfjtSqgzzTIkO9RrWjI+wKmMzlsrT0HlH3lsm9wWgFToOp4RjFVpHJyshHBlxYWh2SNiYW64MbzWbALtTwvxPtxsmCa87ysTFTXJbgrWHS2GzO/HxhgKc8cxKPLOY5dtwR6d/UqTSq+jD9SwfaURGrFLtNnVgEob3ikFDs8OlCk0PD8ddO6GPZi0AS+i12Z2IsFqU1ygyOC0aCy5ignP9UdWxOCi/Tw6nhA3Cds5zSw7glvc3e0xm5o4OF6j60BUAJYmac6S4awqd3SeqYLOr+UYUuvKfbi907HY7HnjgAfz888/Ytm0bnnvuOZSVuWb/E0RPg4eaBqVGIyIkyMverYdPHI+wWvDODWNxx5Tsdn9OQAxd2RSLf2BKFCJb8JpP6x2LsGALSmttylyrVC9hK85MuVfQaysP418rDuFUdSPCrRbcMLEPTCbmOPGKrlPVjWh2SAi2mJAWw9wxk8mEM+Xw1eqDJfhOnne24KJhSIoKweHiWjy35IDmOSvqbErC761n9EVipBV1Nge+2nocT36/FwDw5dbjsDucSsVVv6QI5bNaIfc5GpulOn4mk0lJGP7Puny3ZeAVdTZFQFw/oTeCzCYcr2hQBAKf9D7IIEzI4U7jgaIapbT9gOC0GFVy8dDeVjd9iwBV6IyUWwoUVTei2eHU5C/pexYdKdFWWnWVhGSen8PDxQeLaqnM3E+6vdDZuHEjhg4dil69eiEyMhKzZs3C0qVLO3tZBNHp8AqjCf3ivezZNkwblIyXrhqFH+87Uxlp0RHwZOSyuiZslk8KLc1JCgmyKF2av5S7HfsqdC49LQMDU6JQVmfDS8sPAQDOzElEbLhVCetxV4dXXGXEhWvcIp7U/MWW4zhW3oAIqwWXj87A05cMBwB8tumYptfNBjm/Jic5EslRoThLfvz/Ldqt5AdV1DdjQ2654uj0S4pQejDx3B59wviMwSmIDg1CbZPdJcTD4WGpzPgwJEervZK4q8OFzuA09y0EMuPCEWG1wGZnQszucGqcld90lVyV9TZFkOibO4rw0NWIjFgArEFiflk9RH1wsKhWU3l1RH5/eJiNO26dDf9OXz4mAyFBZjQ0O7pcsnRXp9OFzi+//ILZs2cjPT0dJpMJixYtctln4cKFyMrKQmhoKCZMmICNGzcq9xUWFqJXr17K7V69euHEifbvukkQXZ3bzuyHv140FPfLAzrbG4vZhItP66U0D+woeHiirNamVBCNy2q5uJssd8fmoy7SfRQ6MeHB+PaeyZg/I0eZxzVrWBoAdX4XFwf6/BzOpOwEmEysAggAzhmSgjCrBdMGJSMmLBg1TXbsLlRDF+tlUcE7ek+RexQ5nBIirBZMkUOHH28sULoD902M0OTMmExQ5n1xzGaT0meICxY9PGw1MCVas4b1sgvDK66GpLlvwmk2m5S17C2sRl5ZPWwOpzKiZP+pGk1fo+3HKpXrh4tr3fYc4o7O0PRoWMwmOCXVAeodHw6ziSUc85YETqek9M7h71lXEBOSJCku5fi+8UrIcb+bz6Sz+eVgidtcss6k04VOXV0dRo4ciYULFxre/+mnn+KBBx7A448/jq1bt2LkyJGYOXMmiotpIi1BeCIiJAg3TMxCdGiw9527MdzROVXViD3yj6wYivEX/byz1Bj3peV6QoIsmD9jAJbePwVvXD9GmUY/MJWdzLk4UCuutMeODbcqLgQAzJEfbzGbcLrszIl9b3jy78R+TGSclZMEbhD96YLByjiRxXLX4vSYUIRbgzRdtQemRCEm3PU7wgXK3kI3QkdurjdIPtbkbPa+Ld1bhOKaRuw7yRORPTeF5IJq38lqHJKPOTg1ShFAYoLz1oJK5Xptk2uJOIcnH6fHhiFZHvHCq8sGpEQqOUO88upEZQOa7E5YLWZl1lxn5ejUNdlxw7sb8eT3e7HrRBUq6psRGmzG0PQY5b3WV7t1BXYdr8IN727Eje9u9NgOoTPodKEza9YsPPXUU7jkkksM73/hhRdw22234eabb8aQIUPwxhtvIDw8HO+++y4AID09XePgnDhxAunp7is9mpqaUF1drflHEET3hefo1DTZYXdKSI0ORS8PfW+8MSQtWqmUAryXlhvRNzEC5w1TO0LzExQPXeXrSstFeJl5bHgwzuivJnNPkoUEP/GfqmpUxMYEWejERVjxzGUj8IfzBuHa8b0xKTsRUaFBSsiGz0ZLjAxRKqXcicKhXhwdLmS4aDq9XwJGZsSgtsmOhz/fidLaJphNLEfME4qjc7JaeT0DUqIUwSGGr/TzxPQl4gBrjMidmtSYUGVO3KY8JnR6x0egv9zZm4e/eNgqKzFcSeI/XtEAp1PC/lPVOPfF1YYjPtqD346U4ZeDJfj3mlxc8cY6AMCozFi54SV7r4wSkqvqmzs1d+e/6/MAsFy0o12ss3SnCx1P2Gw2bNmyBTNmzFC2mc1mzJgxA+vWsS/A+PHjsXv3bpw4cQK1tbVYvHgxZs6c6faYTz/9NGJiYpR/mZmZ7f46CIJoP+J0s8DGZsW1qjmi2WxSTrJAy4SOHh5yOFhUC6dTEhwd1zDf5WMykJUQjnvOztFMmedr2pRXjia7A5/LU9jHZ8UrrhYAXDE2E3dOzYbJZII1yKzM8QJYfg6Hh6umyFPZ9ShOS2G1y1/oTqekjEvgjo3ZbMJfLxoGk4klUwOs8i3M6nl22RAhdMWF4ICUKEzuz4VOmfKc22VHJ1N2wozydHijQWuQGXHhwUiRHZ28MtVF4529ef4RnwGWnRSJtFhWZddkd6Kktgn//jUXB4tq8YaHXkacTXnlyC8zPskXVjbg/k+3ex3cKj6+Sa624p+VXjBzVh0oxsi/LsXUf67EW78cMWzCyJEkya3jYnc4sfpgiabKyxcq6234Zrs6p23XiUq/Ht/edGmhU1paCofDgZQUbWJjSkoKTp1iHUiDgoLw/PPPY9q0aRg1ahQefPBBJCS4n0D96KOPoqqqSvl37Fj7zVshCKL9CbaYNQ7M2DZojsjdEwBKVVRryEoIh1VOJN1dWKWczIwcnT4JEVj18DTcekZfzfb+yZFIjAxBk92JLXkV+EQur752Qm+Pz33esFTlutgt+qlLhuE/t4zHOUOME8f7J0fCajGjpsmu5Ctxjlc0oN7mgDXIrOlXNDIzFlePU/941PfPMWJgahTMclUaT64ekBqFcVnxsJhNyC+rx/GKehwuqUVNkx3hVgvOH85yn/Ql4oAatkqJDoHJZHJJJu+TEKFUMHFH6IiQqB1sMSviNre0Dsvkfki7TlR5nPheUFaPq95ch2vf3mAoJN5YfQRfbzuBl1d4nkfGG17eNCkL14zvjYy4MCWEyYVOfnk96prU2WmLd7Hz4bHyBvz9x/0496XVhj2QyutsGPe3Fbjzoy2Gz/3G6iO48d2N+PuP+zyuUc8XW44rogwAdh7vWnk6XVro+MqcOXNw8OBBHD58GLfffrvHfUNCQhAdHa35RxBE90Z0NMa2IhGZc2ZOIkwmNiqCh3haQ5DFrJxcL1q4FpX1zbCYTUo3aV8wmVSn6bmlB3CisgExYcEaIWPElAFJCJddlWyho3ViZIjHPkfBFjMGpLL9955kJ67PNx/DFW/8hvNf/hUA68mj73z98MxBivAc4oPQCQ22KCE1PsZjYEoUokKDcZrc/+nN1UexVU40H5Gh5qoYOTqnqtgJno8kSYnWCp3eCeHKUFr+eNHRAVg1GAB8ueU4KgV3hJe2G3GwqAZOieX7bJcH6Yrw6qkdBveJ8F4/Q9Kj8fSlw7HmD2crjmBCZAiSokLk2Wmqq7PtGDv2NeMzkRIdgqLqJqWPk8iGo2UorW3Ckj1FLuM6JEnCF3Kjz083HfPoCok4nZLSj4n3ktolCJ3WjvNoC7q00ElMTITFYkFRUZFme1FREVJTPf/nJgii55Aod0eOsFqUk2Br6JMQgdevG403fzemzSba8zlbksT+Mn/pqlF+9/rhQmebHMK5bHSG0ujPHaHBFjx50TBcN6G3krTsK2JYqbi6EY9+tQub8ipQ22RHSJAZ1xi4SfERVrx01ShMH5SMK+TJ7r4+DwBEhwYhJZp9nvNnsIrB/67Px3tr8wCw3jt6oXKsvB73f7odu09UKRVXXODwZGSAVZhlxIWhf3IkTCY2CLa8ziY4OkzocKeNh2OC5AzvXw66Di7liMJh2V7tOau2ya7k1eSX1XsczKmMMHFTvagPX9U0NivO1v3nDMDV49hn8ouBKBPzrZbr1rj7RLUS3mtoduDzLZ6jHftOVmPl/mK8uzYXeWX1iAoJwmMXsMHIewqrYXc4YbM7cedHW3H631d0ajVWlxY6VqsVY8aMwYoVK5RtTqcTK1aswMSJEztxZQRBdCW4ozO6T1ybCZPzhqUpfW3agvkzBuChcwfgizsmYvF9Z7ZoPIYYUgPYX/C+cNmYDPztkuF+vzdcgOwprMZHGwpgd0oYkRGDJfPPwp4FM/G70/sYPm7qwGT8+6ZxSiKwN8QQ18DUKCXH6oycRNw0KQuAWuU1uneckmtUXmdDWW0T/vHTfny97QTu/GgLcuVRDtzREUNXbDSKBWFWCzLiWEjyunc2oFieacaPy3OAbHLPIh5G/OVgidv8lhOVqmuhFxHbCyo1PXx2CGXyu45XKe0EbHYnTshhwiw3bh/Pndooh/l2Hq+CJAG9YsNYL6UB7Duy5nCpS3KyWEG3VLdG3qAyJoy5cR+sy4PDKcHucGLt4VJNqOzXQyWY9a9fcfP7m/DUDyzMddmYDAxNj0aE1YKGZgeOlNThl4MlqGpoRmJkiE9hzPai04VObW0ttm/fju3btwMAcnNzsX37dhQUFAAAHnjgAbz99tv44IMPsG/fPtx5552oq6vDzTff3ImrJgiiK9FHPilMzPbPsehIUmNCcffZORibFd/iZOnM+DClomxcVpzLFPm2ZqjsQu06UYWPN7Lf5Lln9sPA1Kg2E5SAevIG4PKa/nDeIE0S9Wm9YxFuDVLeh9+OlGHJbjVH5X8bmRPBBY4YuhL7Fg1OVcvaARZ24a0YxP0iQ4Jwz/QcRFgtKKuzKZPi9Yhdlw8V1yoz1wBgszCUEwC2yUJn8a6TmP3qGiz4dg8AFvZySkBYsAVJUcbz1aYNZMnjKw8Uw+5wKr2FTusdCwAYmRGLqJAgVNY3Y0+h1kURHZ31R8uUWWJOp4Tvd8iduOcMRWx4MI6VN+Czzcfwu39vxHXvbMA1b6+Hze5Es8OJBd+xrtu948MxMiMGUwcm4c6p2TCbTcp4lZ3HK/GNfMzZI9O9jlFpT9q/L7wXNm/ejP9v797Doqz2PYB/Z4aZ4TqM3Ge4iaIoysUrkmUapLjNS7WTjLaaqWVYbi9F6lFL9wmffKzz2HabZx+L7anHsjI7ZnsXpuAlREXZ5SUEIkjlYuIgilxnnT9gXplARJthdPh+nmeeB953zbgW6xV/rvVba40ZM0b6ftGiRQCAGTNmIC0tDYmJibh48SJWrlyJsrIyREdH41//+lebBGUi6r5eGBOKcL1GOobBXslkMkyM0uPdzELMeaCX1f880zSJacTDV6PG+FvkBN2J1lNXYb8JdJxUCvxXYjSmbs5Cf50Gni0bRPbxdcV5w3W8+fWP0rYCZVdqpVEMU4Dj63Yj0AluNUry6vh+6OfnhiBPFwz010jTYYB5oDOmnw9c1Q64L9QL6afLsT//IiIC2m6CaAp0lAoZGpoE0k+XY86o5j7Kackv6uvrirPlV6URne0tK+cyzl6EEEKatgr2dL5pMDw0uAe0zkpcrmlATvFlacl9dEs+k4NCjvtCPfH1qXIcyP9V2pep8lo9Slt2jPbXOuG84Toyz17EI5F6HC+5jAtVtXBVOyBhoB/OlF3B5syfsHTHD9Kf+/25Kqz7+kfo3J1QUHEVni4q7HrxfmkEyCQywB3ZRZU4/FMl0k83B6Cm/aRsxeYjOqNHj4YQos0rLS1NKjN//nwUFxejrq4O2dnZiImJsV2Fieiu4+6kxORo/1vmq9iDJWP7IntZHMZ2QVDn5qg0Cw6SYoKhtOBIjom3m1rKy2lviiMyQIsDrzyED2ff+N0f2pJPYzqTaukf+uHxwTdygkwjOhonBzgqm+vcepVbL29XLBobhj8OCUA/P43ZiIMpGRkAElp+zqYdk01noP2WKdCZ0LIizJSn02QUUk6VaQrs3+cMMNTU40B+c87Pxeo6XKiqRfGvNwKdm3FQyPFQy6hO+unyViM6N1YbmqZc95+9UVfTtFWwpzMeiTSv466WkZexA3zhqFTgTyOCpY0nQ31c8R8T+gMA/n6gSDpvbcm4sDZBDgBEtARWO3PPo7bBiBAvFyk/zVZsHugQEVHnOSjkbVYSWZNptEWlkGPa8I6Xsv8e65+IxrI/9MOwm2xg6O2mhrPqxiSEaS8coHkF2fiBOqx4pD907o5wUiqkFVQymUz6eQV18ngSL1cVwnUaBHo4YXTLsRqmQCen5DIuVpsv3W5sMkpJ0NNbcoqOFVei8lo98sqqcbWuEa5qB0yO9ofKQQ5DTQP+e/9PaGyVQ5NbYpCSgW+WiGwS37IlwKfHz+HXq/VQKmTSBo8ApMNhj5dclvJ/TCvnwnUaaUuBfT9W4PMT57Az98YUE9B8Btv6qVFYENcHXySPxOwHekm5UtcbmjBAr8HUoe3nh0W2BDWmkbVJUfrfta+VJTDQISKimzItGZ4crb9p3ogl3N/HC3NH9e70P4qhrZbKPzU8ECoHObTOKnz10gP4ZuEosy0HJkfpEeTh3OlVZzKZDP83fyTSFz4Il5aVcYEezuiv06DJKDD9vSMw1NxYOVVeXQejaJ62ig7QIlyngVEA7x8qQk7L1NKgIC0clQopINlysAgApNGmEyWXpf2VbnVe3Ki+3lAp5NLS93Cdxmw0M9jTBUEezmhoEsg2HbLaMqIzQK/BoKAe8HRR4UptIxZ+/G9UXW9AL28X3N/q+JNHBwVg4cN9pfa/Or4fIgPc4SCX4fVJA26acxPs6QyN442AdJKNp60ABjpERNSBp0cE4+/Th2LNlIG2roqZPr5uUDvIoVTIzJa593BRtTksddHYMOx/ZcxtBWoOCnmbqdB3pkXDy1WNM6VXkPQ/2dJeM6ZpK527E+RyGabHNq9Ge2dvAd75tvkk+yEtG1macmlMG+yZcq1yfzFIR4PcbMWViavaASNaJd63nrYyMY3qmKavTInI4S0HnZpGb7xc1Vgyti92zLuvw2lJR6UC25+LxYGUMR3uVSWTyaS8oAh/d2lkzZYY6BAR0U0pFXI8HO571+U/aRyV2DprOLbNGWGR3as7I9THDdvmxMDTRYVTF65g+c7mZF1ToKPXNk+RPTk8CIsfbt4DyJTI/dtAB2geiXl0kD+A5pVtpoNEO7ORZOsdrVt/psnoljyeHcfP45fKGhS2bIpoOqz11fH98Nm8WBx6dQzmP9QHWudbb4zpqFR06mdtqtuMlukuW2OgQ0RE96SYXp4W2Qn7dvTxdcPGpMEAbuyrc14KdG4EAS/G9cHL48IANJ+7ZQpGWgclj0TpEOLlAncnJeoajWhoElAp5J0KJuL73zijzLS0vLWH+vkgKsAd1XWNmPu/OWgyCni4qKSkb0elAkOCPaB2sHwA+6cRwTi6PB5/7OSGkdZm8+XlRERE95IhwT3gqJTjSm0jfvr1mjSi4681D1CSx4Sij48rnFQKuLXs0RPk4Yyens4ou1KLiZHNibpRgVppiinQw6lTe87o3J3wn48ORG2Dsd2cHoVchr9MicCkjQelvYLCdZouSQyWy2VWzee6XQx0iIiIboNSIUekvxZHfq7EiZLLuNCyK3J7IzG/3QZAJpPh4+dica2uUcolGtQq0LnViqvWkmLa35naJCLAHX8aEYytWc1nUbVemdWddNupq40bNyI8PBzDhg2zdVWIiOgeY5ouOl5iaJOjcyu+GkfpXC0AiG419XSrFVe3a/HYMOlg2oE23s/GVrptoJOcnIzTp0/j6NGjtq4KERHdY0yBTvOITvtTV50V3bJKCeh4s8A74e6kRNozw/FKQphVdrW+F3DqioiI6DaZlnTnlVdDtOz7p7vDQKeHiwp9fFyRX3HVbCNESxno795tR3MABjpERES3zVfjKJ0ZBTSPnLiq7/yf1LcTo/Hvc4ZOb2pIncdAh4iI6A5EB2nbXVp+J7r7qIs1ddscHSIiot9jUKs9cfw7mYhMXY+BDhER0R1offTC7x3RIethoENERHQHBug1UCqaN+BjoHP3YqBDRER0BxyVCkS05NUEe1h2WThZDpORiYiI7tBfpkQg8+xFxPX3vXVhsgkGOkRERHcoXK9BeDc9WuFewakrIiIislsMdIiIiMhuMdAhIiIiu8VAh4iIiOwWAx0iIiKyWwx0iIiIyG4x0CEiIiK71W0DnY0bNyI8PBzDhg2zdVWIiIjISmRCCGHrSthSVVUVtFotfvnlF2g03PSJiIjoXnDlyhUEBgbCYDDA3d39puW6/c7I1dXVAIDAwEAb14SIiIhuV3V1dYeBTrcf0TEajbhw4QLc3Nwgk8ks9rmmSLO7jhSx/Ww/28/2s/1svzXbL4RAdXU19Ho95PKbZ+J0+xEduVyOgIAAq32+RqPplg+6CdvP9rP9bH93xfZbv/0djeSYdNtkZCIiIrJ/DHSIiIjIbjHQsRK1Wo1Vq1ZBrVbbuio2wfaz/Ww/28/2s/13g26fjExERET2iyM6REREZLcY6BAREZHdYqBDREREdouBDhEREdktBjpWsnHjRvTs2ROOjo6IiYnBkSNHbF0li0tNTcWwYcPg5uYGHx8fTJkyBXl5eWZlRo8eDZlMZvZ6/vnnbVRjy3vttdfatK9fv37S/draWiQnJ8PT0xOurq54/PHHUV5ebsMaW1bPnj3btF8mkyE5ORmA/fX//v37MXHiROj1eshkMuzcudPsvhACK1euhE6ng5OTE+Lj45Gfn29WprKyEklJSdBoNNBqtXj22Wdx9erVLmzFneuo/Q0NDUhJSUFERARcXFyg1+sxffp0XLhwwewz2ntm1q5d28UtuTO36v+ZM2e2aVtCQoJZGXvtfwDt/i6QyWRYt26dVMYW/c9Axwo+/vhjLFq0CKtWrcLx48cRFRWFcePGoaKiwtZVs6jMzEwkJyfj8OHDSE9PR0NDA8aOHYtr166ZlZszZw5KS0ul15tvvmmjGlvHgAEDzNp38OBB6d7ChQuxa9cufPLJJ8jMzMSFCxfw2GOP2bC2lnX06FGztqenpwMAnnjiCamMPfX/tWvXEBUVhY0bN7Z7/80338SGDRvw7rvvIjs7Gy4uLhg3bhxqa2ulMklJSTh16hTS09Px5ZdfYv/+/Zg7d25XNeF36aj9NTU1OH78OFasWIHjx49jx44dyMvLw6RJk9qUXb16tdkz8eKLL3ZF9X+3W/U/ACQkJJi1bdu2bWb37bX/AZi1u7S0FO+99x5kMhkef/xxs3Jd3v+CLG748OEiOTlZ+r6pqUno9XqRmppqw1pZX0VFhQAgMjMzpWsPPvigWLBgge0qZWWrVq0SUVFR7d4zGAxCqVSKTz75RLp25swZAUBkZWV1UQ271oIFC0Tv3r2F0WgUQth3/wMQn3/+ufS90WgUfn5+Yt26ddI1g8Eg1Gq12LZtmxBCiNOnTwsA4ujRo1KZf/7zn0Imk4nz5893Wd0t4bftb8+RI0cEAFFcXCxdCw4OFm+//bZ1K9cF2mv/jBkzxOTJk2/6nu7W/5MnTxYPPfSQ2TVb9D9HdCysvr4eOTk5iI+Pl67J5XLEx8cjKyvLhjWzvqqqKgCAh4eH2fUPP/wQXl5eGDhwIJYuXYqamhpbVM9q8vPzodfr0atXLyQlJaGkpAQAkJOTg4aGBrNnoV+/fggKCrLLZ6G+vh4ffPABZs2aZXZArr33v0lRURHKysrM+tvd3R0xMTFSf2dlZUGr1WLo0KFSmfj4eMjlcmRnZ3d5na2tqqoKMpkMWq3W7PratWvh6emJQYMGYd26dWhsbLRNBa0gIyMDPj4+CAsLw7x583Dp0iXpXnfq//LycuzevRvPPvtsm3td3f/d/lBPS/v111/R1NQEX19fs+u+vr748ccfbVQr6zMajfjzn/+MkSNHYuDAgdL1p556CsHBwdDr9fj++++RkpKCvLw87Nixw4a1tZyYmBikpaUhLCwMpaWleP311/HAAw/g5MmTKCsrg0qlavNL3tfXF2VlZbapsBXt3LkTBoMBM2fOlK7Ze/+3ZurT9v7um+6VlZXBx8fH7L6DgwM8PDzs7pmora1FSkoKpk2bZnaw40svvYTBgwfDw8MD3333HZYuXYrS0lK89dZbNqytZSQkJOCxxx5DSEgICgsLsWzZMowfPx5ZWVlQKBTdqv//8Y9/wM3Nrc1UvS36n4EOWURycjJOnjxplp8CwGzuOSIiAjqdDnFxcSgsLETv3r27upoWN378eOnryMhIxMTEIDg4GNu3b4eTk5MNa9b1tmzZgvHjx0Ov10vX7L3/qX0NDQ2YOnUqhBDYtGmT2b1FixZJX0dGRkKlUuG5555DamrqXXNkwJ168sknpa8jIiIQGRmJ3r17IyMjA3FxcTasWdd77733kJSUBEdHR7Prtuh/Tl1ZmJeXFxQKRZuVNeXl5fDz87NRraxr/vz5+PLLL7Fv3z4EBAR0WDYmJgYAUFBQ0BVV63JarRZ9+/ZFQUEB/Pz8UF9fD4PBYFbGHp+F4uJi7NmzB7Nnz+6wnD33v6lPO/q77+fn12ZRQmNjIyorK+3mmTAFOcXFxUhPTzcbzWlPTEwMGhsb8fPPP3dNBbtQr1694OXlJT3v3aH/AeDAgQPIy8u75e8DoGv6n4GOhalUKgwZMgTffvutdM1oNOLbb79FbGysDWtmeUIIzJ8/H59//jn27t2LkJCQW74nNzcXAKDT6axcO9u4evUqCgsLodPpMGTIECiVSrNnIS8vDyUlJXb3LLz//vvw8fHBhAkTOixnz/0fEhICPz8/s/6+cuUKsrOzpf6OjY2FwWBATk6OVGbv3r0wGo1SEHgvMwU5+fn52LNnDzw9PW/5ntzcXMjl8jZTOvbg3LlzuHTpkvS823v/m2zZsgVDhgxBVFTULct2Sf93aepzN/HRRx8JtVot0tLSxOnTp8XcuXOFVqsVZWVltq6aRc2bN0+4u7uLjIwMUVpaKr1qamqEEEIUFBSI1atXi2PHjomioiLxxRdfiF69eolRo0bZuOaWs3jxYpGRkSGKiorEoUOHRHx8vPDy8hIVFRVCCCGef/55ERQUJPbu3SuOHTsmYmNjRWxsrI1rbVlNTU0iKChIpKSkmF23x/6vrq4WJ06cECdOnBAAxFtvvSVOnDghrSpau3at0Gq14osvvhDff/+9mDx5sggJCRHXr1+XPiMhIUEMGjRIZGdni4MHD4o+ffqIadOm2apJt6Wj9tfX14tJkyaJgIAAkZuba/Y7oa6uTgghxHfffSfefvttkZubKwoLC8UHH3wgvL29xfTp023css7pqP3V1dViyZIlIisrSxQVFYk9e/aIwYMHiz59+oja2lrpM+y1/02qqqqEs7Oz2LRpU5v326r/GehYyTvvvCOCgoKESqUSw4cPF4cPH7Z1lSwOQLuv999/XwghRElJiRg1apTw8PAQarVahIaGipdffllUVVXZtuIWlJiYKHQ6nVCpVMLf318kJiaKgoIC6f7169fFCy+8IHr06CGcnZ3Fo48+KkpLS21YY8v7+uuvBQCRl5dndt0e+3/fvn3tPvMzZswQQjQvMV+xYoXw9fUVarVaxMXFtfm5XLp0SUybNk24uroKjUYjnnnmGVFdXW2D1ty+jtpfVFR0098J+/btE0IIkZOTI2JiYoS7u7twdHQU/fv3F2+88YZZIHA366j9NTU1YuzYscLb21solUoRHBws5syZ0+Y/uPba/yabN28WTk5OwmAwtHm/rfpfJoQQ1hsvIiIiIrId5ugQERGR3WKgQ0RERHaLgQ4RERHZLQY6REREZLcY6BAREZHdYqBDREREdouBDhEREdktBjpERK1kZGRAJpO1OaOMiO5NDHSIiIjIbjHQISIiIrvFQIeI7ipGoxGpqakICQmBk5MToqKi8OmnnwK4Ma20e/duREZGwtHRESNGjMDJkyfNPuOzzz7DgAEDoFar0bNnT6xfv97sfl1dHVJSUhAYGAi1Wo3Q0FBs2bLFrExOTg6GDh0KZ2dn3HfffcjLy7Nuw4nIKhjoENFdJTU1FVu3bsW7776LU6dOYeHChXj66aeRmZkplXn55Zexfv16HD16FN7e3pg4cSIaGhoANAcoU6dOxZNPPokffvgBr732GlasWIG0tDTp/dOnT8e2bduwYcMGnDlzBps3b4arq6tZPZYvX47169fj2LFjcHBwwKxZs7qk/URkWTzUk4juGnV1dfDw8MCePXsQGxsrXZ89ezZqamowd+5cjBkzBh999BESExMBAJWVlQgICEBaWhqmTp2KpKQkXLx4Ed988430/ldeeQW7d+/GqVOncPbsWYSFhSE9PR3x8fFt6pCRkYExY8Zgz549iIuLAwB89dVXmDBhAq5fvw5HR0cr/xSIyJI4okNEd42CggLU1NTg4Ycfhqurq/TaunUrCgsLpXKtgyAPDw+EhYXhzJkzAIAzZ85g5MiRZp87cuRI5Ofno6mpCbm5uVAoFHjwwQc7rEtkZKT0tU6nAwBUVFT87jYSUddysHUFiIhMrl69CgDYvXs3/P39ze6p1WqzYOdOOTk5daqcUqmUvpbJZACa84eI6N7CER0iumuEh4dDrVajpKQEoaGhZq/AwECp3OHDh6WvL1++jLNnz6J///4AgP79++PQoUNmn3vo0CH07dsXCoUCERERMBqNZjk/RGS/OKJDRHcNNzc3LFmyBAsXLoTRaMT999+PqqoqHDp0CBqNBsHBwQCA1atXw9PTE76+vli+fDm8vLwwZcoUAMDixYsxbNgwrFmzBomJicjKysJf//pX/O1vfwMA9OzZEzNmzMCsWbOwYcMGREVFobi4GBUVFZg6daqtmk5EVsJAh4juKmvWrIG3tzdSU1Px008/QavVYvDgwVi2bJk0dbR27VosWLAA+fn5iI6Oxq5du6BSqQAAgwcPxvbt27Fy5UqsWbMGOp0Oq1evxsyZM6U/Y9OmTVi2bBleeOEFXLp0CUFBQVi2bJktmktEVsZVV0R0zzCtiLp8+TK0Wq2tq0NE9wDm6BAREZHdYqBDREREdotTV0RERGS3OKJDREREdouBDhEREdktBjpERERktxjoEBERkd1ioENERER2i4EOERER2S0GOkRERGS3GOgQERGR3WKgQ0RERHbr/wFdJGjwUpy5yQAAAABJRU5ErkJggg==\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Val loss: 1.397790789604187\n",
+            "Train loss: 0.9393936395645142\n",
+            "Test loss: 0.9468271732330322\n",
+            "dO18 RMSE: 0.9135236042418461\n",
+            "EXPECTED:\n",
+            "    d18O_cel_mean  d18O_cel_variance\n",
+            "0       26.748000           0.532670\n",
+            "1       25.706000           0.568880\n",
+            "2       26.738000           0.005370\n",
+            "3       24.376000           0.581130\n",
+            "4       27.220000           0.269650\n",
+            "5       27.434000           0.501030\n",
+            "6       28.156000           0.999030\n",
+            "7       26.836000           0.120880\n",
+            "8       28.180000           0.778250\n",
+            "9       26.834000           0.094930\n",
+            "10      26.644000           0.488430\n",
+            "11      26.772000           0.373370\n",
+            "12      27.684280           1.216389\n",
+            "13      27.403235           0.892280\n",
+            "14      26.628000           0.365370\n",
+            "\n",
+            "PREDICTED:\n",
+            "    d18O_cel_mean  d18O_cel_variance\n",
+            "0       27.014885           1.154062\n",
+            "1       27.014885           1.154062\n",
+            "2       27.014885           1.154062\n",
+            "3       27.014885           1.154062\n",
+            "4       27.014885           1.154062\n",
+            "5       27.722965           1.819614\n",
+            "6       27.591928           1.791299\n",
+            "7       27.591928           1.791299\n",
+            "8       27.591928           1.791299\n",
+            "9       27.591928           1.791299\n",
+            "10      27.591928           1.791299\n",
+            "11      27.591928           1.791299\n",
+            "12      27.722965           1.819614\n",
+            "13      27.591928           1.791298\n",
+            "14      27.014885           1.154062\n"
+          ]
+        }
+      ],
       "source": [
         "model = train_and_evaluate(data, MODEL_NAME, training_batch_size=3)"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 48,
       "metadata": {
-        "id": "nX1HiL-NfR3a"
+        "id": "nX1HiL-NfR3a",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "769510be-3189-4a40-904a-6231c4ba3b4f"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "['/content/gdrive/MyDrive/amazon_rainforest_files/variational/model/demo_isoscape_model.pkl']"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 48
+        }
+      ],
       "source": [
         "model.save(get_model_save_location(\n",
         "    f\"{MODEL_NAME}.tf\"), save_format='tf')\n",
@@ -577,9 +1126,45 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "PuGJblTjiDdz"
+        "id": "PuGJblTjiDdz",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "d505b361-4751-43f9-a02f-96016664f904"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Driver: GTiff/GeoTIFF\n",
+            "Size is 941 x 937 x 12\n",
+            "Projection is GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4326\"]]\n",
+            "Origin = (-74.0000000000241, 5.29166666665704)\n",
+            "Pixel Size = (0.04166666666665718, -0.04166666666667143)\n",
+            "Driver: GTiff/GeoTIFF\n",
+            "Size is 941 x 937 x 12\n",
+            "Projection is GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4326\"]]\n",
+            "Origin = (-74.0000000000241, 5.29166666665704)\n",
+            "Pixel Size = (0.04166666666665718, -0.04166666666667143)\n",
+            "Driver: GTiff/GeoTIFF\n",
+            "Size is 942 x 936 x 1\n",
+            "Projection is GEOGCS[\"SIRGAS 2000\",DATUM[\"Sistema_de_Referencia_Geocentrico_para_las_AmericaS_2000\",SPHEROID[\"GRS 1980\",6378137,298.257222101004,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6674\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4674\"]]\n",
+            "Origin = (-74.0, 5.25)\n",
+            "Pixel Size = (0.041666666666666664, -0.041666666666666664)\n",
+            "Driver: GTiff/GeoTIFF\n",
+            "Size is 5418 x 4683 x 2\n",
+            "Projection is GEOGCS[\"SIRGAS 2000\",DATUM[\"Sistema_de_Referencia_Geocentrico_para_las_AmericaS_2000\",SPHEROID[\"GRS 1980\",6378137,298.257222101004,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6674\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4674\"]]\n",
+            "Origin = (-73.991666667, 5.275)\n",
+            "Pixel Size = (0.008333333333333335, -0.008333333333333333)\n",
+            "Driver: GTiff/GeoTIFF\n",
+            "Size is 5418 x 4683 x 2\n",
+            "Projection is GEOGCS[\"SIRGAS 2000\",DATUM[\"Sistema_de_Referencia_Geocentrico_para_las_AmericaS_2000\",SPHEROID[\"GRS 1980\",6378137,298.257222101004,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6674\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4674\"]]\n",
+            "Origin = (-73.991666667, 5.275)\n",
+            "Pixel Size = (0.008333333333333335, -0.008333333333333333)\n"
+          ]
+        }
+      ],
       "source": [
         "# @title Run this cell to generate an isoscape\n",
         "\n",
@@ -600,14 +1185,13 @@
         "    'ordinary_kriging_linear_d18O_predicted_variance',]\n",
         "\n",
         "raster.generate_isoscapes_from_variational_model(\n",
-        "    MODEL_NAME, model, data.feature_scaler, required_geotiffs, False)"
+        "    model, required_geotiffs, 1024, 1024, MODEL_NAME, False)"
       ]
     }
   ],
   "metadata": {
     "colab": {
-      "provenance": [],
-      "include_colab_link": true
+      "provenance": []
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/dnn/variational_inference.ipynb
+++ b/dnn/variational_inference.ipynb
@@ -13,7 +13,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -102,7 +102,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "metadata": {
         "id": "AXh86HFwXiax",
         "colab": {
@@ -133,7 +133,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -181,7 +181,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": null,
       "metadata": {
         "id": "6XMee1aHfcik"
       },
@@ -216,7 +216,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 30,
+      "execution_count": null,
       "metadata": {
         "id": "XSDwdvMkb7w8"
       },
@@ -260,7 +260,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 31,
+      "execution_count": null,
       "metadata": {
         "id": "_kf2e_fKon2P"
       },
@@ -328,7 +328,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 32,
+      "execution_count": null,
       "metadata": {
         "id": "urGjYNNnemX6"
       },
@@ -396,7 +396,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 45,
+      "execution_count": null,
       "metadata": {
         "id": "HCkGSPUo3KqY"
       },
@@ -406,7 +406,7 @@
         "from keras.initializers import glorot_normal\n",
         "\n",
         "def get_early_stopping_callback():\n",
-        "  return EarlyStopping(monitor='val_loss', patience=30, min_delta=0.001,\n",
+        "  return EarlyStopping(monitor='val_loss', patience=100, min_delta=0.001,\n",
         "                       verbose=1, restore_best_weights=True, start_from_epoch=0)\n",
         "\n",
         "tf.keras.utils.set_random_seed(18731)\n",
@@ -467,7 +467,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 46,
+      "execution_count": null,
       "metadata": {
         "id": "DALuUm8UOgNu"
       },
@@ -523,7 +523,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 43,
+      "execution_count": null,
       "metadata": {
         "collapsed": true,
         "id": "rPONfgkjvJWz",
@@ -598,7 +598,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 47,
+      "execution_count": null,
       "metadata": {
         "id": "cFuIPM4afQPd",
         "colab": {
@@ -1095,7 +1095,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 48,
+      "execution_count": null,
       "metadata": {
         "id": "nX1HiL-NfR3a",
         "colab": {


### PR DESCRIPTION
Currently, the training notebook does not run out-of-the-box after running the data ingestion notebook. A minimal set of modifications did not produce a good model, so I also performed some minor tuning to help ensure a good out-of-box experience for anyone who tries this.

Changelist:
* Changed input paths to match the "_demo" files that will automatically be created by the latest data_ingestion.ipynb
* Add xavier initialization (network was not initialized, and doing so is considered a best practice)
* Changed patience from 2000 to 30 to avoid overtraining
* Updated arguments to raster.generate_isoscapes_from_variational_model() to match latest code in ddf_common
* Re-introduced reference cell outputs

Reference Performance (splits from https://github.com/tnc-br/ddf_common/pull/46):
Val loss: 1.397790789604187
Train loss: 0.9393936395645142
Test loss: 0.9468271732330322
dO18 RMSE: 0.9135236042418461